### PR TITLE
integration/elastic: add compress test to assert log ingestion

### DIFF
--- a/tests/elasticsearch/compress.bats
+++ b/tests/elasticsearch/compress.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+load "$HELPERS_ROOT/test-helpers.bash"
+
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT TEST_NAMESPACE FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG ELASTICSEARCH_IMAGE_REPOSITORY ELASTICSEARCH_IMAGE_TAG
+
+load "$BATS_DETIK_ROOT/utils.bash"
+load "$BATS_DETIK_ROOT/linter.bash"
+load "$BATS_DETIK_ROOT/detik.bash"
+load "$BATS_SUPPORT_ROOT/load.bash"
+load "$BATS_ASSERT_ROOT/load.bash"
+load "$BATS_FILE_ROOT/load.bash"
+
+setup_file() {
+    echo "recreating namespace $TEST_NAMESPACE"
+    run kubectl delete namespace "$TEST_NAMESPACE"
+    run kubectl create namespace "$TEST_NAMESPACE"
+    # HELM_VALUES_EXTRA_FILE is a default file containing global helm
+    # options that can be optionally applied on helm install/upgrade
+    # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
+    # if not passed.
+    if [ -e  "${HELM_VALUES_EXTRA_FILE}" ]; then
+      envsubst < "${HELM_VALUES_EXTRA_FILE}" > "${HELM_VALUES_EXTRA_FILE%.*}"
+      export HELM_VALUES_EXTRA_FILE="${HELM_VALUES_EXTRA_FILE%.*}"
+    fi
+}
+
+teardown_file() {
+    if [[ "${SKIP_TEARDOWN:-no}" != "yes" ]]; then
+        run kubectl delete namespace "$TEST_NAMESPACE"
+        rm -f ${HELM_VALUES_EXTRA_FILE}
+    fi
+}
+
+# These are required for bats-detik
+# shellcheck disable=SC2034
+DETIK_CLIENT_NAME="kubectl -n $TEST_NAMESPACE"
+# shellcheck disable=SC2034
+DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
+
+
+@test "test fluent-bit forwards logs to elasticsearch default index using http compression" {
+    helm repo add elastic https://helm.elastic.co/ ||  helm repo add elastic https://helm.elastic.co
+    helm repo add fluent https://fluent.github.io/helm-charts/ || helm repo add fluent https://fluent.github.io/helm-charts
+    helm repo update --fail-on-repo-update-fail
+
+    helm upgrade --install --debug --create-namespace --namespace "$TEST_NAMESPACE" elasticsearch elastic/elasticsearch \
+        --values ${BATS_TEST_DIRNAME}/resources/helm/elasticsearch-compress.yaml \
+        --set image=${ELASTICSEARCH_IMAGE_REPOSITORY} --set imageTag=${ELASTICSEARCH_IMAGE_TAG} \
+        --values "$HELM_VALUES_EXTRA_FILE" \
+        --wait
+
+    try "at most 15 times every 2s " \
+        "to find 1 pods named 'elasticsearch-master-0' " \
+        "with 'status' being 'running'"
+
+    helm upgrade --install --debug --create-namespace --namespace "$TEST_NAMESPACE" fluent-bit fluent/fluent-bit \
+        --values ${BATS_TEST_DIRNAME}/resources/helm/fluentbit-compress.yaml \
+        --set image.repository=${FLUENTBIT_IMAGE_REPOSITORY},image.tag=${FLUENTBIT_IMAGE_TAG} \
+        --values "$HELM_VALUES_EXTRA_FILE" \
+        --wait
+
+    try "at most 15 times every 2s " \
+        "to find 1 pods named 'fluent-bit' " \
+        "with 'status' being 'running'"
+
+    attempt=0
+    while true; do
+    	run kubectl exec -q -n "$TEST_NAMESPACE" elasticsearch-master-0 -- curl --insecure --compressed -s -w "%{http_code}" http://localhost:9200/fluentbit/_search/ -o /dev/null
+        if [[ "$output" != "200" ]]; then
+            if [ "$attempt" -lt 25 ]; then
+                attempt=$(( attempt + 1 ))
+                sleep 5
+            else
+                fail "did not find any index results even after $attempt attempts"
+            fi
+        else
+            break
+        fi
+    done
+}

--- a/tests/elasticsearch/resources/helm/elasticsearch-compress.yaml
+++ b/tests/elasticsearch/resources/helm/elasticsearch-compress.yaml
@@ -1,0 +1,15 @@
+protocol: http
+httpPort: 9200
+transportPort: 9300
+replicas: 1
+minimumMasterNodes: 1
+createCert: false
+extraEnvs:
+  - name: http.compression
+    value: "true"
+  - name: xpack.security.enabled
+    value: "false"
+  - name: xpack.security.http.ssl.enabled
+    value: "false"
+  - name: xpack.security.transport.ssl.enabled
+    value: "false"

--- a/tests/elasticsearch/resources/helm/fluentbit-compress.yaml
+++ b/tests/elasticsearch/resources/helm/fluentbit-compress.yaml
@@ -1,0 +1,27 @@
+kind: Deployment
+replicaCount: 1
+rbac:
+  create: false
+config:
+  service: |
+    [SERVICE]
+        Flush 5
+        Daemon Off
+        Log_Level debug
+        HTTP_Server On
+        HTTP_Listen 0.0.0.0
+        HTTP_Port 2020
+  inputs: |
+    [INPUT]
+        Name dummy
+        Tag dummy.log
+        Dummy {"message": "testing"}
+        Rate 10
+  outputs: |
+    [OUTPUT]
+        Name es
+        Match *
+        Host elasticsearch-master
+        Port 9200
+        Index fluentbit
+        compress gzip


### PR DESCRIPTION
when using the compress config parameter.

I was however unable to get the CI scripts running locally, so I am not sure how well it will work. I think it should work though! :crossed_fingers: 

I added extra parameters to the helm chart (compared with the basic one) to ensure that https would not be enabled.

Because compression is disabled if https is enabled, as documented at: https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-network.html see `http.compression`. 

I also call curl with `--compressed`, to be sure that elasticsearch also is correctly supporting compression, so that it would fail there as well as from fluentbit, making possible debugging easier.

Signed-off-by: Renato Arruda <renato.arruda@schibsted.com>