### PR TITLE
Turn off all but monitoring

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,14 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - ./.github/**
+      - ./packer/**
   pull_request:
+    paths-ignore:
+      - ./.github/**
+      - ./packer/**
+
 jobs:
   run-tests:
     name: Run BATS 🦇 tests.

--- a/.github/workflows/update-packer-vm.yaml
+++ b/.github/workflows/update-packer-vm.yaml
@@ -6,11 +6,13 @@ on:
     branches:
       - main
       - master
-    paths:
-      - packer/
+    paths-ignore:
+      - ./.github/**
+      - ./terraform/**
   pull_request:
-    paths:
-      - packer/
+    paths-ignore:
+      - ./.github/**
+      - ./terraform/**
 
 concurrency:
   group: ${{ github.workflow }}

--- a/packer/provision.sh
+++ b/packer/provision.sh
@@ -33,6 +33,10 @@ mkdir -p /opt/fluent-bit-ci/
 git clone --depth 1 https://github.com/fluent/fluent-bit-ci.git /opt/fluent-bit-ci/
 chmod -R a+r /opt/fluent-bit-ci/
 
+# Add ops-agent for monitoring
+curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+bash add-google-cloud-ops-agent-repo.sh --also-install
+
 df -h
 SCRIPT
 

--- a/scripts/docker-compose-monitor.sh
+++ b/scripts/docker-compose-monitor.sh
@@ -125,7 +125,7 @@ pushd "$TEST_DIRECTORY" || exit 1
             $DOCKER_COMPOSE_CMD config --services
             cat > prometheus.yml << PROM_EOF
 global:
-  scrape_interval:     5s # By default, scrape targets every 15 seconds.
+  # scrape_interval is set to the default, scrape targets every 15 seconds.
   # scrape_timeout is set to the global default (10s).
   external_labels:
       monitor: 'test'

--- a/scripts/docker-compose-monitor.sh
+++ b/scripts/docker-compose-monitor.sh
@@ -156,7 +156,7 @@ PROM_EOF
         # Now append to our compose stack
         DOCKER_COMPOSE_FULL_CMD="$DOCKER_COMPOSE_CMD -f docker-compose.yml -f monitoring.yml"
         cat > monitoring.yml << COMPOSE_EOF
-version: "3"
+version: "3.4"
 
 services:
   $PROM_SERVICE_NAME:


### PR DESCRIPTION
Disables as much of the stack as possible once test run is completed. This should then hopefully allow information to be easily extracted plus everything cleaned up.

Adds Ops Agent to allow monitoring of the VM more directly as well.