### PR TITLE
packer: use compute-optmised machine based on metrics

### DIFF
--- a/.github/workflows/call-run-performance-test.yaml
+++ b/.github/workflows/call-run-performance-test.yaml
@@ -43,6 +43,7 @@ concurrency:
 
 env:
   VM_NAME: ${{ inputs.vm-name }}
+  MACHINE_TYPE: e2-standard-8
 jobs:
   setup-vm-instance:
     runs-on: ubuntu-latest
@@ -76,6 +77,7 @@ jobs:
       - name: Deploy VM
         run: |
           gcloud compute instances create "$VM_NAME" --image="fb-perf-test-ubuntu-2004" \
+            --machine-type="$MACHINE_TYPE" \
             --metadata=SELF_DESTRUCT_INTERVAL_MINUTES=720
           sleep 30
         shell: bash

--- a/packer/gcp-packer.json
+++ b/packer/gcp-packer.json
@@ -16,7 +16,7 @@
 
       "instance_name": "fb-perf-test-{{uuid}}",
 
-      "machine_type": "c2-standard-16",
+      "machine_type": "e2-standard-8",
       "disk_size": "500",
 
       "ssh_username": "packer",

--- a/packer/gcp-packer.json
+++ b/packer/gcp-packer.json
@@ -16,7 +16,7 @@
 
       "instance_name": "fb-perf-test-{{uuid}}",
 
-      "machine_type": "e2-standard-8",
+      "machine_type": "c2-standard-16",
       "disk_size": "500",
 
       "ssh_username": "packer",


### PR DESCRIPTION
Updated the machine type as it seems to be CPU bound looking at metrics.

Signed-off-by: Patrick Stephens <pat@calyptia.com>