### PR TITLE
terraform: provide GKE and AKS support for integration tests

### DIFF
--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -59,6 +59,7 @@ jobs:
       aks-kubeconfig: ${{ steps.aks-kubeconfig.outputs.stdout }}
     env:
       # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret
+      # Note these have to be set in the Terraform Cloud workspace as well
       ARM_CLIENT_ID: ${{ secrets.azure-client-id }}
       ARM_CLIENT_SECRET: ${{ secrets.azure-client-secret }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.azure-subscription-id }}

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -61,6 +61,7 @@ jobs:
       # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret
       ARM_CLIENT_ID: ${{ secrets.azure-client-id }}
       ARM_CLIENT_SECRET: ${{ secrets.azure-client-secret }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.azure-subscription-id }}
       ARM_TENANT_ID: ${{ secrets.azure-tenant-id }}
     steps:
       - uses: actions/checkout@v3
@@ -71,12 +72,6 @@ jobs:
         with:
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets.terraform_api_token }}
-
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y azure-cli
-          az login --service-principal --username '${{ secrets.azure-client-id }}' --password '${{ secrets.azure-client-secret }}' --tenant '${{ secrets.azure-tenant-id }}'
-        shell: bash
 
       - id: 'auth'
         uses: 'google-github-actions/auth@v0'

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -165,17 +165,54 @@ jobs:
         run: terraform output -no-color -raw aws-opensearch-endpoint
         working-directory: terraform/
 
+      - name: Get TF helper variables
+        id: tf-config
+        run: |
+          GKE_CLUSTER_NAME=$(terraform output -raw gke_kubernetes_cluster_name)
+          echo $GKE_CLUSTER_NAME
+          echo "::set-output name=gke-cluster-name::$GKE_CLUSTER_NAME"
+
+          GKE_REGION=$(terraform output -raw gke_region)
+          echo $GKE_REGION
+          echo "::set-output name=gke-cluster-region::$GKE_REGION"
+
+          AKS_CLUSTER_NAME=$(terraform output -raw aks_cluster_name)
+          echo $AKS_CLUSTER_NAME
+          echo "::set-output name=aks-cluster-name::$AKS_CLUSTER_NAME"
+
+          AKS_RG=$(terraform output -raw aks_resource_group)
+          echo $AKS_RG
+          echo "::set-output name=aks-cluster-resource-group::$AKS_RG"
+        shell: bash
+
+      - name: Azure login
+        run: |
+          az login --username="$ARM_CLIENT_ID" --password="$ARM_CLIENT_SECRET" --tenant="$ARM_TENANT_ID" --service-principal
+        shell: bash
+
       - name: Get the GKE Kubeconfig
+        run: |
+          export KUBECONFIG=../gke-kubeconfig
+          gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --region "$GKE_REGION"
+        working-directory: terraform/
+        env:
+          GKE_CLUSTER_NAME: ${{ steps.tf-config.outputs.gke-cluster-name }}
+          GKE_REGION: ${{ steps.tf-config.outputs.gke-cluster-region }}
+
+      - name: export the GKE Kubeconfig
         id: gke-kubeconfig
         run: |
-          gcloud container clusters get-credentials $(terraform output -raw gke_kubernetes_cluster_name) --region $(terraform output -raw gke_region)
-        working-directory: terraform/
+          cat gke-kubeconfig
+        shell: bash
 
       - name: Get the AKS Kubeconfig
         id: aks-kubeconfig
         run: |
-          terraform output -no-color -raw aks_kubeconfig
+          az aks get-credentials --name "$AKS_CLUSTER_NAME" --resource-group "$AKS_CLUSTER_RG" --admin --file -
         working-directory: terraform/
+        env:
+          AKS_CLUSTER_NAME: ${{ steps.tf-config.outputs.aks-cluster-name }}
+          AKS_CLUSTER_RG: ${{ steps.tf-config.outputs.aks-cluster-resource-group }}
 
   call-run-integration-kind:
     name: Run integration tests on KIND

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -61,8 +61,8 @@ jobs:
       # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret
       ARM_CLIENT_ID: ${{ secrets.azure-client-id }}
       ARM_CLIENT_SECRET: ${{ secrets.azure-client-secret }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.azure-subscription-id }}
-      ARM_TENANT_ID: ${{ secrets.azure-tenant-id }}
+      ARM_      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+TENANT_ID: ${{ secrets.azure-tenant-id }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -72,6 +72,12 @@ jobs:
         with:
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets.terraform_api_token }}
+
+      - run:
+          sudo apt-get update
+          sudo apt-get install -y azure-cli
+          az login --service-principal --username '${{ secrets.azure-client-id }}' --password '${{ secrets.azure-client-secret }}' --tenant '${{ secrets.azure-tenant-id }}'
+        shell: bash
 
       - id: 'auth'
         uses: 'google-github-actions/auth@v0'

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -98,7 +98,7 @@ jobs:
           cluster_name: kind
 
       - name: Set up Helm
-        uses: azure/setup-helm@v2.1
+        uses: azure/setup-helm@v3.0
         with:
           version: v3.8.1
 

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -79,6 +79,11 @@ jobs:
           sed -i -e "s|\$OPENSEARCH_AWS_SECRET_KEY|${{ secrets.opensearch_aws_secret_key }}|g" default.auto.tfvars
           sed -i -e "s|\$OPENSEARCH_ADMIN_PASSWORD|${{ secrets.opensearch_admin_password }}|g" default.auto.tfvars
 
+          sed -i -e "s|\$AZURE_CLIENT_ID|${{ secrets.azure-client-id }}|g" default.auto.tfvars
+          sed -i -e "s|\$AZURE_CLIENT_SECRET|${{ secrets.azure-client-secret }}|g" default.auto.tfvars
+          sed -i -e "s|\$AZURE_SUBSCRIPTION_ID|${{ secrets.azure-subscription-id }}|g" default.auto.tfvars
+          sed -i -e "s|\$AZURE_TENANT_ID|${{ secrets.azure-tenant-id }}|g" default.auto.tfvars
+
           cat <<EOT >> default.auto.tfvars
           gcp_sa_key    =  <<-EOF
           ${{ secrets.gcp-service-account-key }}

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -168,19 +168,19 @@ jobs:
       - name: Get TF helper variables
         id: tf-config
         run: |
-          GKE_CLUSTER_NAME=$(terraform output -raw gke_kubernetes_cluster_name)
+          GKE_CLUSTER_NAME=$(terraform output -no-color -raw gke_kubernetes_cluster_name)
           echo $GKE_CLUSTER_NAME
           echo "::set-output name=gke-cluster-name::$GKE_CLUSTER_NAME"
 
-          GKE_REGION=$(terraform output -raw gke_region)
+          GKE_REGION=$(terraform output -no-color -raw gke_region)
           echo $GKE_REGION
           echo "::set-output name=gke-cluster-region::$GKE_REGION"
 
-          AKS_CLUSTER_NAME=$(terraform output -raw aks_cluster_name)
+          AKS_CLUSTER_NAME=$(terraform output -no-color -raw aks_cluster_name)
           echo $AKS_CLUSTER_NAME
           echo "::set-output name=aks-cluster-name::$AKS_CLUSTER_NAME"
 
-          AKS_RG=$(terraform output -raw aks_resource_group)
+          AKS_RG=$(terraform output -no-color -raw aks_resource_group)
           echo $AKS_RG
           echo "::set-output name=aks-cluster-resource-group::$AKS_RG"
         shell: bash

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -56,11 +56,9 @@ jobs:
     outputs:
       aks-cluster-name: ${{ steps.aks-cluster-name.outputs.stdout }}
       aks-cluster-resource-group: ${{ steps.aks-cluster-resource-group.outputs.stdout }}
-      aks-kubeconfig: ${{ steps.kubeconfig.outputs.aks-kubeconfig }}
       aws-opensearch-endpoint: ${{ steps.aws-opensearch-endpoint.outputs.stdout }}
       gke-cluster-name: ${{ steps.gke-cluster-name.outputs.stdout }}
       gke-cluster-region: ${{ steps.gke-cluster-region.outputs.stdout }}
-      gke-kubeconfig: ${{ steps.kubeconfig.outputs.gke-kubeconfig }}
     env:
       # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret
       # Note these have to be set in the Terraform Cloud workspace as well
@@ -190,32 +188,6 @@ jobs:
         working-directory: terraform
         shell: bash
 
-      - name: Get the GKE Kubeconfig
-        run: |
-          export KUBECONFIG=./gke-kubeconfig
-          gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --region "$GKE_REGION"
-        shell: bash
-        env:
-          GKE_CLUSTER_NAME: ${{ steps.gke-cluster-name.outputs.stdout }}
-          GKE_REGION: ${{ steps.gke-cluster-region.outputs.stdout }}
-
-      - name: Get the AKS Kubeconfig
-        run: |
-          az login --username="$ARM_CLIENT_ID" --password="$ARM_CLIENT_SECRET" --tenant="$ARM_TENANT_ID" --service-principal
-          export KUBECONFIG=./aks-kubeconfig
-          az aks get-credentials --name "$AKS_CLUSTER_NAME" --resource-group "$AKS_CLUSTER_RG" --admin
-        shell: bash
-        env:
-          AKS_CLUSTER_NAME: ${{ steps.aks-cluster-name.outputs.stdout }}
-          AKS_CLUSTER_RG: ${{ steps.aks-cluster-resource-group.outputs.stdout }}
-
-      - name: Export the Kubeconfigs
-        id: kubeconfig
-        run: |
-          echo ::set-output name=aks-kubeconfig::$(cat aks-kubeconfig)
-          echo ::set-output name=gke-kubeconfig::$(cat gke-kubeconfig)
-        shell: bash
-
   call-run-integration-kind:
     name: Run integration tests on KIND
     needs:
@@ -287,6 +259,14 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - if: matrix.cloud == 'gke'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: ${{ secrets.gcp-service-account-key }}
+
+      - if: matrix.cloud == 'gke'
+        uses: 'google-github-actions/setup-gcloud@v0'
+
       - name: Setup BATS
         uses: mig4/setup-bats@v1
         with:
@@ -300,20 +280,32 @@ jobs:
       - name: Set up Kubectl
         uses: azure/setup-kubectl@v3.0
 
-      - name: Set up kubeconfig access
+      - name: Get the GKE Kubeconfig
+        if: matrix.cloud == 'gke'
         run: |
-          cat << AKS_EOF > './aks-kubeconfig'
-          ${{ needs.call-run-terraform-setup.outputs.aks-kubeconfig }}
-          AKS_EOF
-
-          cat << GKE_EOF > './gke-kubeconfig'
-          ${{ needs.call-run-terraform-setup.outputs.gke-kubeconfig }}
-          GKE_EOF
+          gcloud info
+          gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --region "$GKE_REGION"
         shell: bash
+        env:
+          GKE_CLUSTER_NAME: ${{ needs.call-run-terraform-setup.outputs.gke-cluster-name }}
+          GKE_REGION: ${{ needs.call-run-terraform-setup.outputs.gke-cluster-region }}
+
+      - name: Get the AKS Kubeconfig
+        if: matrix.cloud == 'aks'
+        run: |
+          az login --username="$ARM_CLIENT_ID" --password="$ARM_CLIENT_SECRET" --tenant="$ARM_TENANT_ID" --service-principal
+          az aks get-credentials --name "$AKS_CLUSTER_NAME" --resource-group "$AKS_CLUSTER_RG" --admin
+        shell: bash
+        env:
+          AKS_CLUSTER_NAME: ${{ needs.call-run-terraform-setup.outputs.outputs.aks-cluster-name }}
+          AKS_CLUSTER_RG: ${{ needs.call-run-terraform-setup.outputs.outputs.aks-cluster-resource-group }}
+          ARM_CLIENT_ID: ${{ secrets.azure-client-id }}
+          ARM_CLIENT_SECRET: ${{ secrets.azure-client-secret }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.azure-subscription-id }}
+          ARM_TENANT_ID: ${{ secrets.azure-tenant-id }}
 
       - name: Run tests
         run:  |
-          export KUBECONFIG=./${{ matrix.cloud }}-kubeconfig
           kubectl cluster-info
           ./run-tests.sh
         shell: bash

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -15,6 +15,21 @@ on:
       terraform_api_token:
         description: Default terraform API token to use when running integration tests.
         required: true
+      gcp-service-account-key:
+        description: The GCP service account key to use.
+        required: true
+      azure-client-id:
+        description: The Azure client ID to use.
+        required: true
+      azure-client-secret:
+        description: The Azure client secret to use.
+        required: true
+      azure-subscription-id:
+        description: The Azure subscription to use.
+        required: true
+      azure-tenant-id:
+        description: The Azure tenant ID to use.
+        required: true
     inputs:
       image_name:
         description: The image repository and name to use.
@@ -33,8 +48,104 @@ on:
         default: main
 jobs:
 
+  call-run-terraform-setup:
+    name: Run Terraform set up
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+      id-token: write
+    outputs:
+      aws-opensearch-endpoint: ${{ steps.aws-opensearch-endpoint.outputs.stdout }}
+    env:
+      # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret
+      ARM_CLIENT_ID: ${{ secrets.azure-client-id }}
+      ARM_CLIENT_SECRET: ${{ secrets.azure-client-secret }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.azure-subscription-id }}
+      ARM_TENANT_ID: ${{ secrets.azure-tenant-id }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.terraform_api_token }}
+
+      - name: Replace terraform variables.
+        run: |
+          sed -i -e "s|\$OPENSEARCH_AWS_ACCESS_ID|${{ secrets.opensearch_aws_access_id }}|g" default.auto.tfvars
+          sed -i -e "s|\$OPENSEARCH_AWS_SECRET_KEY|${{ secrets.opensearch_aws_secret_key }}|g" default.auto.tfvars
+          sed -i -e "s|\$OPENSEARCH_ADMIN_PASSWORD|${{ secrets.opensearch_admin_password }}|g" default.auto.tfvars
+
+          cat <<EOT >> default.auto.tfvars
+          gcp_sa_key    =  <<-EOF
+          ${{ secrets.gcp-service-account-key }}
+          EOF
+          EOT
+        working-directory: terraform/
+        shell: bash
+
+      - name: Terraform init
+        run: terraform init
+        working-directory: terraform/
+
+      - name: Terraform validate
+        run: terraform validate -no-color
+        working-directory: terraform/
+
+      - name: Terraform Plan
+        if: github.event_name == 'pull_request'
+        id: plan
+        run: terraform plan -no-color
+        working-directory: terraform
+        continue-on-error: true
+
+      - uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+            <details><summary>Show Plan</summary>
+            \`\`\`\n
+            ${process.env.PLAN}
+            \`\`\`
+            </details>
+            *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform Apply
+        if: github.event_name != 'pull_request'
+        id: apply
+        run: terraform apply -input=false -auto-approve
+        working-directory: terraform
+        env:
+          TF_LOG: TRACE
+
+      - name: Get the AWS OpenSearch endpoint
+        id: aws-opensearch-endpoint
+        run: terraform output -no-color -raw aws-opensearch-endpoint
+        working-directory: terraform/
+
   call-run-integration-kind:
     name: Run integration tests on KIND
+    needs:
+      - call-run-terraform-setup
     # Can test for multiple K8S versions with KIND
     strategy:
       fail-fast: false
@@ -51,45 +162,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.terraform_api_token }}
-
-      - name: Replace terraform variables.
-        run: |
-          sed -i -e "s|\$OPENSEARCH_AWS_ACCESS_ID|${{ secrets.opensearch_aws_access_id }}|g" default.auto.tfvars
-          sed -i -e "s|\$OPENSEARCH_AWS_SECRET_KEY|${{ secrets.opensearch_aws_secret_key }}|g" default.auto.tfvars
-          sed -i -e "s|\$OPENSEARCH_ADMIN_PASSWORD|${{ secrets.opensearch_admin_password }}|g" default.auto.tfvars
-        working-directory: terraform/
-        shell: bash
-
-      - name: Terraform init
-        run: terraform init
-        working-directory: terraform/
-
-      - name: Terraform validate
-        run: terraform validate -no-color
-        working-directory: terraform/
-
-      - name: Terraform plan
-        run: terraform plan
-        working-directory: terraform/
-
-      - name: Terraform apply
-        if: ${{ github.event_name != 'pull_request' }}
-        run: terraform apply -input=false -auto-approve
-        working-directory: terraform/
-
-      - name: Get the AWS OpenSearch endpoint
-        id: aws-opensearch-endpoint
-        run: terraform output -no-color -raw aws-opensearch-endpoint
-        working-directory: terraform/
-
       - name: Setup BATS
         uses: mig4/setup-bats@v1
         with:
-          bats-version: 1.6.0
+          bats-version: 1.7.0
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.3.0
@@ -113,7 +189,7 @@ jobs:
         env:
           FLUENTBIT_IMAGE_REPOSITORY: ${{ inputs.image_name }}
           FLUENTBIT_IMAGE_TAG: ${{ inputs.image_tag }}
-          HOSTED_OPENSEARCH_HOST: ${{ steps.aws-opensearch-endpoint.outputs.stdout }}
+          HOSTED_OPENSEARCH_HOST: ${{ needs.call-run-terraform-setup.outputs.aws-opensearch-endpoint }}
           HOSTED_OPENSEARCH_PORT: 443
           HOSTED_OPENSEARCH_USERNAME: admin
           HOSTED_OPENSEARCH_PASSWORD: ${{ secrets.opensearch_admin_password }}

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -54,9 +54,13 @@ jobs:
     permissions:
       packages: read
     outputs:
-      aws-opensearch-endpoint: ${{ steps.aws-opensearch-endpoint.outputs.stdout }}
-      gke-kubeconfig: ${{ steps.gke-kubeconfig.outputs.stdout }}
+      aks-cluster-name: ${{ steps.tf-config.outputs.aks-cluster-name }}
+      aks-cluster-resource-group: ${{ steps.tf-config.outputs.aks-cluster-resource-group }}
       aks-kubeconfig: ${{ steps.aks-kubeconfig.outputs.stdout }}
+      aws-opensearch-endpoint: ${{ steps.tf-config.outputs.aws-opensearch-endpoint }}
+      gke-cluster-name: ${{ steps.tf-config.outputs.gke-cluster-name }}
+      gke-cluster-region: ${{ steps.tf-config.outputs.gke-cluster-region }}
+      gke-kubeconfig: ${{ steps.gke-kubeconfig.outputs.stdout }}
     env:
       # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret
       # Note these have to be set in the Terraform Cloud workspace as well
@@ -160,14 +164,13 @@ jobs:
         env:
           TF_LOG: TRACE
 
-      - name: Get the AWS OpenSearch endpoint
-        id: aws-opensearch-endpoint
-        run: terraform output -no-color -raw aws-opensearch-endpoint
-        working-directory: terraform/
-
       - name: Get TF helper variables
         id: tf-config
         run: |
+          AWS_OS_ENDPOINT=$(terraform output -no-color -raw aws-opensearch-endpoint)
+          echo $AWS_OS_ENDPOINT
+          echo "::set-output name=aws-opensearch-endpoint::$AWS_OS_ENDPOINT"
+
           GKE_CLUSTER_NAME=$(terraform output -no-color -raw gke_kubernetes_cluster_name)
           echo $GKE_CLUSTER_NAME
           echo "::set-output name=gke-cluster-name::$GKE_CLUSTER_NAME"
@@ -184,6 +187,7 @@ jobs:
           echo $AKS_RG
           echo "::set-output name=aks-cluster-resource-group::$AKS_RG"
         shell: bash
+        working-directory: terraform/
 
       - name: Azure login
         run: |
@@ -192,9 +196,9 @@ jobs:
 
       - name: Get the GKE Kubeconfig
         run: |
-          export KUBECONFIG=../gke-kubeconfig
+          export KUBECONFIG=./gke-kubeconfig
           gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --region "$GKE_REGION"
-        working-directory: terraform/
+        shell: bash
         env:
           GKE_CLUSTER_NAME: ${{ steps.tf-config.outputs.gke-cluster-name }}
           GKE_REGION: ${{ steps.tf-config.outputs.gke-cluster-region }}
@@ -202,14 +206,14 @@ jobs:
       - name: export the GKE Kubeconfig
         id: gke-kubeconfig
         run: |
-          cat gke-kubeconfig
+          cat ./gke-kubeconfig
         shell: bash
 
       - name: Get the AKS Kubeconfig
         id: aks-kubeconfig
         run: |
           az aks get-credentials --name "$AKS_CLUSTER_NAME" --resource-group "$AKS_CLUSTER_RG" --admin --file -
-        working-directory: terraform/
+        shell: bash
         env:
           AKS_CLUSTER_NAME: ${{ steps.tf-config.outputs.aks-cluster-name }}
           AKS_CLUSTER_RG: ${{ steps.tf-config.outputs.aks-cluster-resource-group }}

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -302,11 +302,11 @@ jobs:
 
       - name: Set up kubeconfig access
         run: |
-          cat < AKS_EOF > './aks-kubeconfig'
+          cat << AKS_EOF > './aks-kubeconfig'
           ${{ needs.call-run-terraform-setup.outputs.aks-kubeconfig }}
           AKS_EOF
 
-          cat < GKE_EOF > './gke-kubeconfig'
+          cat << GKE_EOF > './gke-kubeconfig'
           ${{ needs.call-run-terraform-setup.outputs.gke-kubeconfig }}
           GKE_EOF
         shell: bash

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -196,8 +196,8 @@ jobs:
           gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --region "$GKE_REGION"
         shell: bash
         env:
-          GKE_CLUSTER_NAME: ${{ steps.tf-config.outputs.gke-cluster-name }}
-          GKE_REGION: ${{ steps.tf-config.outputs.gke-cluster-region }}
+          GKE_CLUSTER_NAME: ${{ steps.gke-cluster-name.outputs.stdout }}
+          GKE_REGION: ${{ steps.gke-cluster-region.outputs.stdout }}
 
       - name: Get the AKS Kubeconfig
         run: |
@@ -206,8 +206,8 @@ jobs:
           az aks get-credentials --name "$AKS_CLUSTER_NAME" --resource-group "$AKS_CLUSTER_RG" --admin
         shell: bash
         env:
-          AKS_CLUSTER_NAME: ${{ steps.tf-config.outputs.aks-cluster-name }}
-          AKS_CLUSTER_RG: ${{ steps.tf-config.outputs.aks-cluster-resource-group }}
+          AKS_CLUSTER_NAME: ${{ steps.aks-cluster-name.outputs.stdout }}
+          AKS_CLUSTER_RG: ${{ steps.aks-cluster-resource-group.outputs.stdout }}
 
       - name: Export the Kubeconfigs
         id: kubeconfig

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -88,10 +88,18 @@ jobs:
         shell: bash
 
       - name: Terraform init
+        id: init
         run: terraform init
         working-directory: terraform/
 
+      - name: Terraform fmt
+        id: fmt
+        run: |
+          find . -name "*.tf" -exec terraform fmt -check {} \;
+        working-directory: terraform
+
       - name: Terraform validate
+        id: validate
         run: terraform validate -no-color
         working-directory: terraform/
 

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -61,8 +61,7 @@ jobs:
       # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret
       ARM_CLIENT_ID: ${{ secrets.azure-client-id }}
       ARM_CLIENT_SECRET: ${{ secrets.azure-client-secret }}
-      ARM_      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-TENANT_ID: ${{ secrets.azure-tenant-id }}
+      ARM_TENANT_ID: ${{ secrets.azure-tenant-id }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -73,7 +72,7 @@ TENANT_ID: ${{ secrets.azure-tenant-id }}
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets.terraform_api_token }}
 
-      - run:
+      - run: |
           sudo apt-get update
           sudo apt-get install -y azure-cli
           az login --service-principal --username '${{ secrets.azure-client-id }}' --password '${{ secrets.azure-client-secret }}' --tenant '${{ secrets.azure-tenant-id }}'

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -73,6 +73,14 @@ jobs:
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets.terraform_api_token }}
 
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: ${{ secrets.gcp-service-account-key }}
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
+
       - name: Replace terraform variables.
         run: |
           sed -i -e "s|\$OPENSEARCH_AWS_ACCESS_ID|${{ secrets.opensearch_aws_access_id }}|g" default.auto.tfvars
@@ -158,12 +166,14 @@ jobs:
 
       - name: Get the GKE Kubeconfig
         id: gke-kubeconfig
-        run: terraform output -no-color -raw gke_kubeconfig
+        run: |
+          gcloud container clusters get-credentials $(terraform output -raw gke_kubernetes_cluster_name) --region $(terraform output -raw gke_region)
         working-directory: terraform/
 
       - name: Get the AKS Kubeconfig
         id: aks-kubeconfig
-        run: terraform output -no-color -raw aks_kubeconfig
+        run: |
+          terraform output -no-color -raw aks_kubeconfig
         working-directory: terraform/
 
   call-run-integration-kind:
@@ -223,16 +233,15 @@ jobs:
     name: Run integration tests on cloud providers
     needs:
       - call-run-terraform-setup
-      - call-run-integration-kind
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        kubeconfig:
-         - ${{ needs.call-run-terraform-setup.outputs.aks-kubeconfig }}
-         - ${{ needs.call-run-terraform-setup.outputs.gke-kubeconfig }}
+        cloud:
+          - aks
+          - gke
     steps:
       - uses: actions/checkout@v3
         with:
@@ -251,12 +260,20 @@ jobs:
       - name: Set up Kubectl
         uses: azure/setup-kubectl@v3.0
 
+      - name: Set up kubeconfig access
+        run: |
+          cat < AKS_EOF > './aks-kubeconfig'
+          ${{ needs.call-run-terraform-setup.outputs.aks-kubeconfig }}
+          AKS_EOF
+
+          cat < GKE_EOF > './gke-kubeconfig'
+          ${{ needs.call-run-terraform-setup.outputs.gke-kubeconfig }}
+          GKE_EOF
+        shell: bash
+
       - name: Run tests
         run:  |
-          export KUBECONFIG=./kubeconfig
-          cat < EOF > './kubeconfig'
-          ${{ matrix.kubeconfig }}
-          EOF
+          export KUBECONFIG=./${{ matrix.cloud }}-kubeconfig
           ./run-tests.sh
         shell: bash
         env:

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -53,9 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: read
-      id-token: write
     outputs:
       aws-opensearch-endpoint: ${{ steps.aws-opensearch-endpoint.outputs.stdout }}
+      gke-kubeconfig: ${{ steps.gke-kubeconfig.outputs.stdout }}
+      aks-kubeconfig: ${{ steps.aks-kubeconfig.outputs.stdout }}
     env:
       # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret
       ARM_CLIENT_ID: ${{ secrets.azure-client-id }}
@@ -140,6 +141,16 @@ jobs:
       - name: Get the AWS OpenSearch endpoint
         id: aws-opensearch-endpoint
         run: terraform output -no-color -raw aws-opensearch-endpoint
+        working-directory: terraform/
+
+      - name: Get the GKE Kubeconfig
+        id: gke-kubeconfig
+        run: terraform output -no-color -raw gke_kubeconfig
+        working-directory: terraform/
+
+      - name: Get the AKS Kubeconfig
+        id: aks-kubeconfig
+        run: terraform output -no-color -raw aks_kubeconfig
         working-directory: terraform/
 
   call-run-integration-kind:

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -297,8 +297,8 @@ jobs:
           az aks get-credentials --name "$AKS_CLUSTER_NAME" --resource-group "$AKS_CLUSTER_RG" --admin
         shell: bash
         env:
-          AKS_CLUSTER_NAME: ${{ needs.call-run-terraform-setup.outputs.outputs.aks-cluster-name }}
-          AKS_CLUSTER_RG: ${{ needs.call-run-terraform-setup.outputs.outputs.aks-cluster-resource-group }}
+          AKS_CLUSTER_NAME: ${{ needs.call-run-terraform-setup.outputs.aks-cluster-name }}
+          AKS_CLUSTER_RG: ${{ needs.call-run-terraform-setup.outputs.aks-cluster-resource-group }}
           ARM_CLIENT_ID: ${{ secrets.azure-client-id }}
           ARM_CLIENT_SECRET: ${{ secrets.azure-client-secret }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.azure-subscription-id }}
@@ -306,7 +306,6 @@ jobs:
 
       - name: Run tests
         run:  |
-          kubectl cluster-info
           ./run-tests.sh
         shell: bash
         env:

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -164,6 +164,7 @@ jobs:
         k8s-release: [ 'v1.23.5', 'v1.22.7', 'v1.21.10' ]
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: read
     steps:
       - name: Test image exists and cache locally
@@ -195,6 +196,54 @@ jobs:
       - name: Run tests
         run:  |
           kind load docker-image ${{ inputs.image_name }}:${{ inputs.image_tag }}
+          ./run-tests.sh
+        shell: bash
+        env:
+          FLUENTBIT_IMAGE_REPOSITORY: ${{ inputs.image_name }}
+          FLUENTBIT_IMAGE_TAG: ${{ inputs.image_tag }}
+          HOSTED_OPENSEARCH_HOST: ${{ needs.call-run-terraform-setup.outputs.aws-opensearch-endpoint }}
+          HOSTED_OPENSEARCH_PORT: 443
+          HOSTED_OPENSEARCH_USERNAME: admin
+          HOSTED_OPENSEARCH_PASSWORD: ${{ secrets.opensearch_admin_password }}
+
+  call-run-integration-cloud:
+    name: Run integration tests on cloud providers
+    needs:
+      - call-run-terraform-setup
+      - call-run-integration-kind
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        kubeconfig:
+         - ${{ needs.call-run-terraform-setup.outputs.aks-kubeconfig }}
+         - ${{ needs.call-run-terraform-setup.outputs.gke-kubeconfig }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup BATS
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.7.0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.0
+        with:
+          version: v3.8.1
+
+      - name: Set up Kubectl
+        uses: azure/setup-kubectl@v3.0
+
+      - name: Run tests
+        run:  |
+          export KUBECONFIG=./kubeconfig
+          cat < EOF > './kubeconfig'
+          ${{ matrix.kubeconfig }}
+          EOF
           ./run-tests.sh
         shell: bash
         env:

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -312,6 +312,7 @@ jobs:
       - name: Run tests
         run:  |
           export KUBECONFIG=./${{ matrix.cloud }}-kubeconfig
+          kubectl cluster-info
           ./run-tests.sh
         shell: bash
         env:

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -54,13 +54,13 @@ jobs:
     permissions:
       packages: read
     outputs:
-      aks-cluster-name: ${{ steps.tf-config.outputs.aks-cluster-name }}
-      aks-cluster-resource-group: ${{ steps.tf-config.outputs.aks-cluster-resource-group }}
-      aks-kubeconfig: ${{ steps.aks-kubeconfig.outputs.stdout }}
-      aws-opensearch-endpoint: ${{ steps.tf-config.outputs.aws-opensearch-endpoint }}
-      gke-cluster-name: ${{ steps.tf-config.outputs.gke-cluster-name }}
-      gke-cluster-region: ${{ steps.tf-config.outputs.gke-cluster-region }}
-      gke-kubeconfig: ${{ steps.gke-kubeconfig.outputs.stdout }}
+      aks-cluster-name: ${{ steps.aks-cluster-name.outputs.stdout }}
+      aks-cluster-resource-group: ${{ steps.aks-cluster-resource-group.outputs.stdout }}
+      aks-kubeconfig: ${{ steps.kubeconfig.outputs.aks-kubeconfig }}
+      aws-opensearch-endpoint: ${{ steps.aws-opensearch-endpoint.outputs.stdout }}
+      gke-cluster-name: ${{ steps.gke-cluster-name.outputs.stdout }}
+      gke-cluster-region: ${{ steps.gke-cluster-region.outputs.stdout }}
+      gke-kubeconfig: ${{ steps.kubeconfig.outputs.gke-kubeconfig }}
     env:
       # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret
       # Note these have to be set in the Terraform Cloud workspace as well
@@ -164,34 +164,30 @@ jobs:
         env:
           TF_LOG: TRACE
 
-      - name: Get TF helper variables
-        id: tf-config
-        run: |
-          AWS_OS_ENDPOINT=$(terraform output -no-color -raw aws-opensearch-endpoint)
-          echo $AWS_OS_ENDPOINT
-          echo "::set-output name=aws-opensearch-endpoint::$AWS_OS_ENDPOINT"
-
-          GKE_CLUSTER_NAME=$(terraform output -no-color -raw gke_kubernetes_cluster_name)
-          echo $GKE_CLUSTER_NAME
-          echo "::set-output name=gke-cluster-name::$GKE_CLUSTER_NAME"
-
-          GKE_REGION=$(terraform output -no-color -raw gke_region)
-          echo $GKE_REGION
-          echo "::set-output name=gke-cluster-region::$GKE_REGION"
-
-          AKS_CLUSTER_NAME=$(terraform output -no-color -raw aks_cluster_name)
-          echo $AKS_CLUSTER_NAME
-          echo "::set-output name=aks-cluster-name::$AKS_CLUSTER_NAME"
-
-          AKS_RG=$(terraform output -no-color -raw aks_resource_group)
-          echo $AKS_RG
-          echo "::set-output name=aks-cluster-resource-group::$AKS_RG"
+      # We're using the terraform wrapper here so separate steps for each output variable
+      - id: aws-opensearch-endpoint
+        run: terraform output -no-color -raw aws-opensearch-endpoint
+        working-directory: terraform
         shell: bash
-        working-directory: terraform/
 
-      - name: Azure login
-        run: |
-          az login --username="$ARM_CLIENT_ID" --password="$ARM_CLIENT_SECRET" --tenant="$ARM_TENANT_ID" --service-principal
+      - id: gke-cluster-name
+        run: terraform output -no-color -raw gke_kubernetes_cluster_name
+        working-directory: terraform
+        shell: bash
+
+      - id: gke-cluster-region
+        run: terraform output -no-color -raw gke_region
+        working-directory: terraform
+        shell: bash
+
+      - id: aks-cluster-name
+        run: terraform output -no-color -raw aks_cluster_name
+        working-directory: terraform
+        shell: bash
+
+      - id: aks-cluster-resource-group
+        run: terraform output -no-color -raw aks_resource_group
+        working-directory: terraform
         shell: bash
 
       - name: Get the GKE Kubeconfig
@@ -203,20 +199,22 @@ jobs:
           GKE_CLUSTER_NAME: ${{ steps.tf-config.outputs.gke-cluster-name }}
           GKE_REGION: ${{ steps.tf-config.outputs.gke-cluster-region }}
 
-      - name: export the GKE Kubeconfig
-        id: gke-kubeconfig
-        run: |
-          cat ./gke-kubeconfig
-        shell: bash
-
       - name: Get the AKS Kubeconfig
-        id: aks-kubeconfig
         run: |
-          az aks get-credentials --name "$AKS_CLUSTER_NAME" --resource-group "$AKS_CLUSTER_RG" --admin --file -
+          az login --username="$ARM_CLIENT_ID" --password="$ARM_CLIENT_SECRET" --tenant="$ARM_TENANT_ID" --service-principal
+          export KUBECONFIG=./aks-kubeconfig
+          az aks get-credentials --name "$AKS_CLUSTER_NAME" --resource-group "$AKS_CLUSTER_RG" --admin
         shell: bash
         env:
           AKS_CLUSTER_NAME: ${{ steps.tf-config.outputs.aks-cluster-name }}
           AKS_CLUSTER_RG: ${{ steps.tf-config.outputs.aks-cluster-resource-group }}
+
+      - name: Export the Kubeconfigs
+        id: kubeconfig
+        run: |
+          echo ::set-output name=aks-kubeconfig::$(cat aks-kubeconfig)
+          echo ::set-output name=gke-kubeconfig::$(cat gke-kubeconfig)
+        shell: bash
 
   call-run-integration-kind:
     name: Run integration tests on KIND

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -33,3 +33,8 @@ jobs:
       opensearch_aws_secret_key: ${{ secrets.OPENSEARCH_AWS_SECRET_KEY }}
       opensearch_admin_password: ${{ secrets.OPENSEARCH_ADMIN_PASSWORD }}
       terraform_api_token: ${{ secrets.TF_API_TOKEN }}
+      gcp-service-account-key: ${{ secrets.GCP_SA_KEY }}
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ tools/bats/lib/*
 *.tar.gz
 *.pem
 *.box
+terraform/.terraform/
+terraform/.terraform.lock.hcl

--- a/PERFORMANCE-TESTS.md
+++ b/PERFORMANCE-TESTS.md
@@ -1,8 +1,11 @@
 # Performance testing
 
-This repository provides a VM image built in GCP automatically to run tests but it can also be built as a Vagrant box manually via Packer.
+A simple script is provided to support running a Docker Compose stack with automated Prometheus monitoring.
+This repository also provides a VM image built in GCP automatically to run tests using this script via Packer.
 
 ## Packer build
+
+This is a simple Ubuntu 20 box built with the various tools required: primarily docker, docker-compose and a few other utilities.
 
 ## Performance monitoring
 

--- a/terraform/default.auto.tfvars
+++ b/terraform/default.auto.tfvars
@@ -1,3 +1,7 @@
 aws_access_id             = "$OPENSEARCH_AWS_ACCESS_ID"
 aws_secret_key            = "$OPENSEARCH_AWS_SECRET_KEY"
 opensearch_admin_password = "$OPENSEARCH_ADMIN_PASSWORD"
+azure_client_id           = "$AZURE_CLIENT_ID"
+azure_client_secret       = "$AZURE_CLIENT_SECRET"
+# azure_subscription_id   = "$AZURE_SUBSCRIPTION_ID"
+# azure_tenant_id         = "$AZURE_TENANT_ID"

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -1,0 +1,58 @@
+# Provide Azure and GKE clusters to run tests on.
+
+## Azure
+resource "azurerm_resource_group" "fluent-bit-ci" {
+  name     = "fluent-bit-ci-k8s-resources"
+  location = var.azure_location
+}
+
+resource "azurerm_kubernetes_cluster" "fluent-bit-ci" {
+  name                = "fluent-bit-ci-k8s"
+  location            = azurerm_resource_group.fluent-bit-ci.location
+  resource_group_name = azurerm_resource_group.fluent-bit-ci.name
+  dns_prefix          = "fluent-bit-ci-k8s"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 3
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+## GKE
+data "google_project" "project" {}
+data "google_client_config" "current" {}
+
+# Provide information about versions available to this region
+data "google_container_engine_versions" "versions" {
+  location = var.gcp_region
+}
+
+resource "google_compute_network" "vpc" {
+  name                    = "vpc-fluent-bit-ci"
+  auto_create_subnetworks = true
+}
+
+resource "google_container_cluster" "fluent-bit-ci-autopilot" {
+  name = "fluent-bit-ci-autopilot"
+  # For autopilot we must use regional clusters
+  location = var.gcp_region
+
+  initial_node_count = 1
+  network            = google_compute_network.vpc.name
+
+  # Always use latest
+  node_version = data.google_container_engine_versions.versions.latest_node_version
+
+  # Enabling Autopilot for this cluster
+  enable_autopilot = true
+
+  # Required to handle this issue: https://github.com/hashicorp/terraform-provider-google/issues/10782
+  ip_allocation_policy {}
+
+  depends_on = [data.google_project.project]
+}

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -24,10 +24,6 @@ resource "azurerm_kubernetes_cluster" "fluent-bit-ci" {
     client_id     = var.azure_client_id
     client_secret = var.azure_client_secret
   }
-
-  role_based_access_control {
-    enabled = true
-  }
 }
 
 output "aks_kube_config" {

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -14,13 +14,19 @@ resource "azurerm_kubernetes_cluster" "fluent-bit-ci" {
   # AKS defaults to latest K8S version
 
   default_node_pool {
-    name       = "default"
-    node_count = 3
-    vm_size    = "Standard_DS2_v2"
+    name            = "default"
+    node_count      = 2
+    vm_size         = "Standard_DS2_v2"
+    os_disk_size_gb = 150
   }
 
-  identity {
-    type = "SystemAssigned"
+  service_principal {
+    client_id     = var.azure_client_id
+    client_secret = var.azure_client_secret
+  }
+
+  role_based_access_control {
+    enabled = true
   }
 }
 

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -27,12 +27,12 @@ resource "azurerm_kubernetes_cluster" "fluent-bit-ci" {
 }
 
 output "aks_cluster_name" {
-  value = azurerm_kubernetes_cluster.fluent-bit-ci.name
+  value       = azurerm_kubernetes_cluster.fluent-bit-ci.name
   description = "AKS cluster name"
 }
 
 output "aks_resource_group" {
-  value = azurerm_resource_group.fluent-bit-ci.name
+  value       = azurerm_resource_group.fluent-bit-ci.name
   description = "AKS cluster resource group"
 }
 

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -55,7 +55,6 @@ resource "google_container_cluster" "fluent-bit-ci-autopilot" {
 
   # Always use latest
   min_master_version = data.google_container_engine_versions.versions.latest_node_version
-
   node_version = data.google_container_engine_versions.versions.latest_node_version
 
   # Enabling Autopilot for this cluster

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -54,6 +54,8 @@ resource "google_container_cluster" "fluent-bit-ci-autopilot" {
   network            = google_compute_network.vpc.name
 
   # Always use latest
+  min_master_version = data.google_container_engine_versions.versions.latest_node_version
+
   node_version = data.google_container_engine_versions.versions.latest_node_version
 
   # Enabling Autopilot for this cluster

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -68,18 +68,12 @@ resource "google_container_cluster" "fluent-bit-ci-autopilot" {
 
   depends_on = [data.google_project.project]
 }
-
-# Get Kubeconfig output
-module "gke_auth" {
-  source = "terraform-google-modules/kubernetes-engine/google/modules/auth"
-
-  project_id   = data.google_project.project
-  cluster_name = google_container_cluster.fluent-bit-ci-autopilot.name
-  location     = google_container_cluster.fluent-bit-ci-autopilot.location
+output "gke_region" {
+  value       = var.gcp_region
+  description = "GCloud Region"
 }
 
-output "gke_kubeconfig" {
-  description = "The Kubeconfig file to use to access the GKE cluster."
-  value       = module.gke_auth.kubeconfig_raw
-  sensitive   = true
+output "gke_kubernetes_cluster_name" {
+  value       = google_container_cluster.fluent-bit-ci-autopilot.name
+  description = "GKE Cluster Name"
 }

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -26,9 +26,14 @@ resource "azurerm_kubernetes_cluster" "fluent-bit-ci" {
   }
 }
 
-output "aks_kube_config" {
-  value     = azurerm_kubernetes_cluster.fluent-bit-ci.kube_config_raw
-  sensitive = true
+output "aks_cluster_name" {
+  value = azurerm_kubernetes_cluster.fluent-bit-ci.name
+  description = "AKS cluster name"
+}
+
+output "aks_resource_group" {
+  value = azurerm_resource_group.fluent-bit-ci.name
+  description = "AKS cluster resource group"
 }
 
 ## GKE

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -53,10 +53,6 @@ resource "google_container_cluster" "fluent-bit-ci-autopilot" {
   initial_node_count = 1
   network            = google_compute_network.vpc.name
 
-  # Always use latest
-  min_master_version = data.google_container_engine_versions.versions.latest_node_version
-  node_version = data.google_container_engine_versions.versions.latest_node_version
-
   # Enabling Autopilot for this cluster
   enable_autopilot = true
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -12,6 +12,14 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.0"
     }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=3.0.1"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.29"
+    }
   }
 }
 
@@ -19,4 +27,14 @@ provider "aws" {
   region     = var.aws_region
   access_key = var.aws_access_id
   secret_key = var.aws_secret_key
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "google" {
+  project     = var.gcp_project + id
+  region      = var.gcp_region
+  credentials = var.gcp_sa_key
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -34,7 +34,7 @@ provider "azurerm" {
 }
 
 provider "google" {
-  project     = var.gcp_project + id
+  project     = var.gcp_project_id
   region      = var.gcp_region
   credentials = var.gcp_sa_key
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,6 +71,18 @@ variable "azure_location" {
   default     = "westus2"
 }
 
+variable "azure_client_id" {
+  type        = string
+  description = "Azure Kubernetes Service Cluster service principal"
+  sensitive   = true
+}
+
+variable "azure_client_secret" {
+  type        = string
+  description = "Azure Kubernetes Service Cluster password"
+  sensitive   = true
+}
+
 variable "gcp_region" {
   type        = string
   description = "The Google region to use for GKE cluster"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -82,6 +82,6 @@ variable "gcp_project_id" {
 }
 
 variable "gcp_sa_key" {
-  type = string
+  type      = string
   sensitive = true
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -83,4 +83,5 @@ variable "gcp_project_id" {
 
 variable "gcp_sa_key" {
   type = string
+  sensitive = true
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,26 +7,26 @@ variable "aws_region" {
 variable "aws_access_id" {
   type        = string
   description = "AWS access ID"
-  sensitive = true
+  sensitive   = true
 }
 
 variable "aws_secret_key" {
   type        = string
   description = "AWS secret key"
-  sensitive = true
+  sensitive   = true
 }
 
 variable "opensearch_master_user_name" {
   type        = string
   description = "Master username for OpenSearch"
   default     = "admin"
-  sensitive = true
+  sensitive   = true
 }
 
 variable "opensearch_admin_password" {
   type        = string
   description = "Master password for OpenSearch"
-  sensitive = true
+  sensitive   = true
 }
 
 variable "opensearch_instance_type" {
@@ -63,4 +63,24 @@ variable "opensearch_version" {
   type        = string
   description = "OpenSearch version"
   default     = "OpenSearch_1.2"
+}
+
+variable "azure_location" {
+  type        = string
+  description = "The Azure Region in which all resources should be provisioned"
+  default     = "westus2"
+}
+
+variable "gcp_region" {
+  type        = string
+  description = "The Google region to use for GKE cluster"
+  default     = "us-east1"
+}
+variable "gcp_project_id" {
+  type    = string
+  default = "fluent-bit-ci"
+}
+
+variable "gcp_sa_key" {
+  type = string
 }

--- a/tests/simple.bats
+++ b/tests/simple.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+load "$HELPERS_ROOT/test-helpers.bash"
+
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT
+
+@test "Verify K8S cluster accessible" {
+    kubectl cluster-info
+}


### PR DESCRIPTION
Resolves #65 by adding AKS and GKE clusters to run tests on.
Also adds a simple test case to call `kubectl cluster-info` as a sanity check.

Requires additional secrets on callers: https://github.com/fluent/fluent-bit/pull/5804 & https://github.com/fluent/fluent-bit-infra/pull/145

Test run: https://github.com/fluent/fluent-bit-ci/runs/7577085547?check_suite_focus=true
Note integration tests were already failing but not reporting failure, possibly the BATS upgrade: https://github.com/fluent/fluent-bit/runs/7553802867?check_suite_focus=true#step:15:93