### PR TITLE
integration: provide timeout and increased node count

### DIFF
--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -230,6 +230,7 @@ jobs:
         uses: azure/setup-kubectl@v3.0
 
       - name: Run tests
+        timeout-minutes: 30
         run:  |
           kind load docker-image ${{ inputs.image_name }}:${{ inputs.image_tag }}
           ./run-tests.sh

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -307,6 +307,7 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.azure-tenant-id }}
 
       - name: Run tests
+        timeout-minutes: 30
         run:  |
           ./run-tests.sh
         shell: bash

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -220,6 +220,7 @@ jobs:
         with:
           node_image: kindest/node:${{ matrix.k8s-release }}
           cluster_name: kind
+          config: tests/kind.yaml
 
       - name: Set up Helm
         uses: azure/setup-helm@v3.1

--- a/.github/workflows/run-integration-tests-pr.yaml
+++ b/.github/workflows/run-integration-tests-pr.yaml
@@ -31,3 +31,8 @@ jobs:
       opensearch_aws_secret_key: ${{ secrets.OPENSEARCH_AWS_SECRET_KEY }}
       opensearch_admin_password: ${{ secrets.OPENSEARCH_ADMIN_PASSWORD }}
       terraform_api_token: ${{ secrets.TF_API_TOKEN }}
+      gcp-service-account-key: ${{ secrets.GCP_SA_KEY }}
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -15,7 +15,7 @@ resource "azurerm_kubernetes_cluster" "fluent-bit-ci" {
 
   default_node_pool {
     name            = "default"
-    node_count      = 2
+    node_count      = 5
     vm_size         = "Standard_DS2_v2"
     os_disk_size_gb = 150
   }

--- a/tests/kind.yaml
+++ b/tests/kind.yaml
@@ -1,0 +1,8 @@
+# Configuration file to use for test clusters with KIND
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/tests/simple.bats
+++ b/tests/simple.bats
@@ -5,5 +5,5 @@ load "$HELPERS_ROOT/test-helpers.bash"
 ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT
 
 @test "Verify K8S cluster accessible" {
-    kubectl cluster-info
+    timeout -k 10 1m kubectl cluster-info
 }


### PR DESCRIPTION
Provides increased node counts for KIND and AKS (GKE is on autopilot).
GKE `kubectl cluster-info` command seems to stall so added 1m timeout.
Added overall test timeouts of 30 minutes - tests should take ~10 minutes.