### PR TITLE
terraform: switch off autopilot for GKE

### DIFF
--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -324,8 +324,6 @@ jobs:
         shell: bash
 
       - name: Run tests
-        # TODO: remove once full set up is passing
-        continue-on-error: true
         timeout-minutes: 30
         run:  |
           ./run-tests.sh

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -324,6 +324,8 @@ jobs:
         shell: bash
 
       - name: Run tests
+        # TODO: remove once full set up is passing
+        continue-on-error: true
         timeout-minutes: 30
         run:  |
           ./run-tests.sh

--- a/terraform/kubernetes.tf
+++ b/terraform/kubernetes.tf
@@ -66,12 +66,24 @@ resource "google_container_cluster" "fluent-bit-ci-autopilot" {
 
   depends_on = [data.google_project.project]
 }
+
+resource "google_container_cluster" "fluent-bit-ci" {
+  name = "fluent-bit-ci"
+  # For autopilot we must use regional clusters
+  location = var.gcp_region
+
+  initial_node_count = 6
+  network            = google_compute_network.vpc.name
+
+  depends_on = [data.google_project.project]
+}
+
 output "gke_region" {
   value       = var.gcp_region
   description = "GCloud Region"
 }
 
 output "gke_kubernetes_cluster_name" {
-  value       = google_container_cluster.fluent-bit-ci-autopilot.name
+  value       = google_container_cluster.fluent-bit-ci.name
   description = "GKE Cluster Name"
 }


### PR DESCRIPTION
GKE Autopilot clusters seem to still have issues running the tests so switched to a fixed cluster.
Test: https://github.com/fluent/fluent-bit-ci/actions/runs/2839411425
Signed-off-by: Patrick Stephens <pat@calyptia.com>