### PR TITLE
workflows: macos: Specify OpenSSL place via -DOPENSSL_ROOT_DIR on global option

### DIFF
--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -38,6 +38,13 @@ else
 fi
 
 GLOBAL_OPTS="-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off"
+
+# On macOS, OpenSSL's root directory should be specified with -DOPENSSL_ROOT_DIR.
+if [ "$(uname)" = "Darwin" ]
+then
+    GLOBAL_OPTS+=" -DOPENSSL_ROOT_DIR=$(brew --prefix openssl)"
+fi
+
 set -e
 mkdir -p "$SOURCE_DIR"/build
 pushd "$SOURCE_DIR"/build || exit 1


### PR DESCRIPTION
This commit is needed by fluent-bit CI task for macOS on https://github.com/fluent/fluent-bit/pull/5887.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>