### PR TITLE
tests: increase timeouts for helm failures

### DIFF
--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -219,7 +219,7 @@ jobs:
       - name: Setup BATS
         uses: mig4/setup-bats@v1
         with:
-          bats-version: 1.7.0
+          bats-version: 1.9.0
 
       - name: Configure system for Opensearch
         run: |
@@ -243,7 +243,7 @@ jobs:
         uses: azure/setup-kubectl@v3.2
 
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 60
         run:  |
           kind load docker-image ${{ inputs.image_name }}:${{ inputs.image_tag }}
           ./run-tests.sh

--- a/helpers/prometheus-snapshot-loader/run.sh
+++ b/helpers/prometheus-snapshot-loader/run.sh
@@ -8,7 +8,10 @@ PROMETHEUS_DATA=${PROMETHEUS_DATA:-$SCRIPT_DIR/prom-data.tgz}
 # Provide a pre-extracted snapshot
 SNAPSHOT_DIR=${SNAPSHOT_DIR:-}
 
-DOCKER_COMPOSE_CMD=${DOCKER_COMPOSE_CMD:-docker-compose}
+DOCKER_COMPOSE_CMD=${DOCKER_COMPOSE_CMD:-docker compose}
+if command -v docker-compose &> /dev/null; then
+    DOCKER_COMPOSE_CMD=docker-compose
+fi
 
 if [[ -f "$PROMETHEUS_DATA" ]]; then
     TEMP_DIR=$(mktemp -d)

--- a/tests/elasticsearch/basic.bats
+++ b/tests/elasticsearch/basic.bats
@@ -48,6 +48,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --values ${BATS_TEST_DIRNAME}/resources/helm/elasticsearch-basic.yaml \
         --set image=${ELASTICSEARCH_IMAGE_REPOSITORY} --set imageTag=${ELASTICSEARCH_IMAGE_TAG} \
         --values "$HELM_VALUES_EXTRA_FILE" \
+        --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
     try "at most 15 times every 2s " \
@@ -58,6 +59,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --values ${BATS_TEST_DIRNAME}/resources/helm/fluentbit-basic.yaml \
         --set image.repository=${FLUENTBIT_IMAGE_REPOSITORY},image.tag=${FLUENTBIT_IMAGE_TAG} \
         --values "$HELM_VALUES_EXTRA_FILE" \
+        --timeout "${HELM_FB_TIMEOUT:-5m0s}" \
         --wait
 
     try "at most 15 times every 2s " \

--- a/tests/elasticsearch/compress.bats
+++ b/tests/elasticsearch/compress.bats
@@ -48,6 +48,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --values ${BATS_TEST_DIRNAME}/resources/helm/elasticsearch-compress.yaml \
         --set image=${ELASTICSEARCH_IMAGE_REPOSITORY} --set imageTag=${ELASTICSEARCH_IMAGE_TAG} \
         --values "$HELM_VALUES_EXTRA_FILE" \
+        --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
     try "at most 15 times every 2s " \
@@ -58,6 +59,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --values ${BATS_TEST_DIRNAME}/resources/helm/fluentbit-compress.yaml \
         --set image.repository=${FLUENTBIT_IMAGE_REPOSITORY},image.tag=${FLUENTBIT_IMAGE_TAG} \
         --values "$HELM_VALUES_EXTRA_FILE" \
+        --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
     try "at most 15 times every 2s " \

--- a/tests/elasticsearch/resources/helm/elasticsearch-basic.yaml
+++ b/tests/elasticsearch/resources/helm/elasticsearch-basic.yaml
@@ -3,3 +3,11 @@ httpPort: 9200
 transportPort: 9300
 replicas: 1
 minimumMasterNodes: 1
+createCert: false
+extraEnvs:
+  - name: xpack.security.enabled
+    value: "false"
+  - name: xpack.security.http.ssl.enabled
+    value: "false"
+  - name: xpack.security.transport.ssl.enabled
+    value: "false"

--- a/tests/opensearch/basic.bats
+++ b/tests/opensearch/basic.bats
@@ -65,6 +65,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --values ${BATS_TEST_DIRNAME}/resources/helm/opensearch-basic.yaml \
         --set image.repository=${OPENSEARCH_IMAGE_REPOSITORY},image.tag=${OPENSEARCH_IMAGE_TAG} \
         --values "$HELM_VALUES_EXTRA_FILE" \
+        --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
     # Note this only means it goes running, it may get killed if a probe fails after that
@@ -76,6 +77,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --values ${BATS_TEST_DIRNAME}/resources/helm/fluentbit-basic.yaml \
         --set image.repository=${FLUENTBIT_IMAGE_REPOSITORY},image.tag=${FLUENTBIT_IMAGE_TAG} \
         --values "$HELM_VALUES_EXTRA_FILE" \
+        --timeout "${HELM_FB_TIMEOUT:-5m0s}" \
         --wait
 
     try "at most 15 times every 2s " \

--- a/tests/opensearch/hosted.bats
+++ b/tests/opensearch/hosted.bats
@@ -50,11 +50,12 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
     envsubst < "${BATS_TEST_DIRNAME}/resources/helm/fluentbit-hosted.yaml.tpl" > "${BATS_TEST_DIRNAME}/resources/helm/fluentbit-hosted.yaml"
 
     helm upgrade --install --debug --create-namespace --namespace "$TEST_NAMESPACE" fluent-bit fluent/fluent-bit \
-    --values $HELM_VALUES_EXTRA_FILE \
-    -f ${BATS_TEST_DIRNAME}/resources/helm/fluentbit-hosted.yaml \
-    --set image.repository=${FLUENTBIT_IMAGE_REPOSITORY} \
-    --set image.tag=${FLUENTBIT_IMAGE_TAG} \
-    --wait
+        --values $HELM_VALUES_EXTRA_FILE \
+        -f ${BATS_TEST_DIRNAME}/resources/helm/fluentbit-hosted.yaml \
+        --set image.repository=${FLUENTBIT_IMAGE_REPOSITORY} \
+        --set image.tag=${FLUENTBIT_IMAGE_TAG} \
+        --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
+        --wait
 
     try "at most 15 times every 2s " \
         "to find 1 pods named 'fluent-bit' " \


### PR DESCRIPTION
Turns out HTTP deployment is broken without some additional settings: https://github.com/elastic/helm-charts/issues/1772
The compression tests were handling it correctly so copied those settings.
Double the default timeouts for helm to 10 minutes as well.
Increment BATS version as well.