### PR TITLE
tests: initial commit of the manual tests

### DIFF
--- a/tests/leonardo/base.sh
+++ b/tests/leonardo/base.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+function elevate_privileges {
+    if [ "$EUID" -ne 0 ]
+    then
+        sudo $0 $@
+        exit
+    fi
+}
+
+function teardown {
+#   [[ -z "$(jobs -p)" ]] || kill -9 $(jobs -p)
+
+    if [ ! -z "${CONTEXT_PATH}" ]
+    then
+        if [ -d "${CONTEXT_PATH}" ]
+        then
+            rm -rf "${CONTEXT_PATH}"
+        fi
+    fi
+
+    rm -f /tmp/source.log 2>&1 >/dev/null
+    
+    pkill -g $$
+    sleep 1
+    pkill -9 -g $$
+}
+
+function delayed_exec_source {
+    sleep $1
+    shift
+    rm -f /tmp/source.log 2>&1 >/dev/null
+    nohup $@ >/tmp/source.log 2>&1
+}
+
+function exec_source {
+    delayed_exec_source 1 $@
+}
+
+function exec_source_after_sink_launches {
+    while [ 1 ]
+    do
+        PTY=$(ps fax | grep $$ | head -n1 | awk '{print $2}')
+        PID=$(ps fax | grep "${PTY}" | grep fluent-bit | grep -v grep | awk '{print $1}')
+
+        if [ -z "${PID}" ]
+        then
+            sleep 0.1
+        else
+            break
+        fi
+    done
+
+    exec_source $@
+}

--- a/tests/leonardo/filter_alter_size_1.sh
+++ b/tests/leonardo/filter_alter_size_1.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SOURCE_ADDRESS="192.168.122.1"
+export SINK_ADDRESS=${SOURCE_ADDRESS}
+export SINK_PORT="4318"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/otelcol_otlp_logs.sh &
+
+./sinks/fb_otlp_filter_alter_size_1.sh

--- a/tests/leonardo/filter_alter_size_2.sh
+++ b/tests/leonardo/filter_alter_size_2.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SOURCE_ADDRESS="192.168.122.1"
+export SINK_ADDRESS=${SOURCE_ADDRESS}
+export SINK_PORT="4318"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/otelcol_otlp_logs.sh &
+
+./sinks/fb_otlp_filter_alter_size_2.sh

--- a/tests/leonardo/filter_checklist.sh
+++ b/tests/leonardo/filter_checklist.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SOURCE_ADDRESS="192.168.122.1"
+export SINK_ADDRESS=${SOURCE_ADDRESS}
+export SINK_PORT="4318"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/otelcol_otlp_logs.sh &
+
+./sinks/fb_otlp_filter_checklist.sh

--- a/tests/leonardo/filter_expect.sh
+++ b/tests/leonardo/filter_expect.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SOURCE_ADDRESS="192.168.122.1"
+export SINK_ADDRESS=${SOURCE_ADDRESS}
+export SINK_PORT="4318"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/otelcol_otlp_logs.sh &
+
+./sinks/fb_otlp_filter_expect.sh

--- a/tests/leonardo/filter_modify_1.sh
+++ b/tests/leonardo/filter_modify_1.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ./setup.sh
+
+./sinks/fb_otlp_filter_modify_1.sh

--- a/tests/leonardo/filter_modify_2.sh
+++ b/tests/leonardo/filter_modify_2.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ./setup.sh
+
+./sinks/fb_otlp_filter_modify_2.sh

--- a/tests/leonardo/filter_rewrite_tag.sh
+++ b/tests/leonardo/filter_rewrite_tag.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ./setup.sh
+
+./sinks/fb_otlp_filter_rewrite_tag.sh

--- a/tests/leonardo/filter_throttle.sh
+++ b/tests/leonardo/filter_throttle.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ./setup.sh
+
+./sinks/fb_otlp_filter_throttle.sh

--- a/tests/leonardo/in_collectd.sh
+++ b/tests/leonardo/in_collectd.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SINK_PORT="25826"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/collectd.sh &
+
+./sinks/fb_collectd.sh

--- a/tests/leonardo/in_elasticsearch.sh
+++ b/tests/leonardo/in_elasticsearch.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SINK_PORT="24224"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/fb_elasticsearch.sh &
+
+./sinks/fb_elasticsearch.sh

--- a/tests/leonardo/in_forward_forward_mode.sh
+++ b/tests/leonardo/in_forward_forward_mode.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SINK_PORT="24224"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/fb_forward_forward_mode.sh &
+
+./sinks/fb_forward.sh

--- a/tests/leonardo/in_forward_legacy_mode.sh
+++ b/tests/leonardo/in_forward_legacy_mode.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SINK_PORT="24224"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/fb_forward_legacy_mode.sh &
+
+./sinks/fb_forward.sh

--- a/tests/leonardo/in_forward_message_mode.sh
+++ b/tests/leonardo/in_forward_message_mode.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SINK_PORT="24224"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/fb_forward_message_mode.sh &
+
+./sinks/fb_forward.sh

--- a/tests/leonardo/in_http.sh
+++ b/tests/leonardo/in_http.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export SINK_PORT="9880"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/shell_http.sh &
+
+./sinks/fb_http.sh

--- a/tests/leonardo/in_https.sh
+++ b/tests/leonardo/in_https.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export SINK_PORT="9880"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/shell_https.sh &
+
+./sinks/fb_https.sh

--- a/tests/leonardo/in_mqtt.sh
+++ b/tests/leonardo/in_mqtt.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/shell_mqtt.sh &
+
+./sinks/fb_mqtt.sh

--- a/tests/leonardo/in_otlp.sh
+++ b/tests/leonardo/in_otlp.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SINK_PORT="4318"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/otelcol_otlp_logs.sh &
+
+./sinks/fb_otlp.sh

--- a/tests/leonardo/in_prometheus.sh
+++ b/tests/leonardo/in_prometheus.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SINK_PORT="9100"
+export SOURCE_PORT="${SINK_PORT}"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/fb_prometheus.sh &
+
+./sinks/fb_prometheus.sh

--- a/tests/leonardo/in_serial.sh
+++ b/tests/leonardo/in_serial.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source ./setup.sh
+
+exec_source ./sources/shell_serial.sh &
+
+sleep 1
+
+./sinks/fb_serial.sh

--- a/tests/leonardo/in_statsd.sh
+++ b/tests/leonardo/in_statsd.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export ELEVATE_PRIVILEGES=1
+export SINK_PORT="8125"
+export SOURCE_PORT="${SINK_PORT}"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/vector_statsd.sh &
+
+./sinks/fb_statsd.sh

--- a/tests/leonardo/in_stdin.sh
+++ b/tests/leonardo/in_stdin.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ./setup.sh
+
+./sources/shell_stdin.sh | ./sinks/fb_stdin.sh

--- a/tests/leonardo/in_syslog.sh
+++ b/tests/leonardo/in_syslog.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export SINK_PORT="5514"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/shell_syslog.sh &
+
+./sinks/fb_syslog.sh

--- a/tests/leonardo/in_tail.sh
+++ b/tests/leonardo/in_tail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export DO_NOT_ELEVATE_PRIVILEGES=1
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/shell_tail.sh &
+
+./sinks/fb_tail.sh

--- a/tests/leonardo/in_tail_multiline.sh
+++ b/tests/leonardo/in_tail_multiline.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export DO_NOT_ELEVATE_PRIVILEGES=1
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/shell_tail_multiline.sh &
+
+./sinks/fb_tail_multiline.sh

--- a/tests/leonardo/in_tail_multiline_legacy.sh
+++ b/tests/leonardo/in_tail_multiline_legacy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export DO_NOT_ELEVATE_PRIVILEGES=1
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/shell_tail_multiline_legacy.sh &
+
+./sinks/fb_tail_multiline_legacy.sh

--- a/tests/leonardo/in_tcp.sh
+++ b/tests/leonardo/in_tcp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export SINK_PORT="5170"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/shell_tcp.sh &
+
+./sinks/fb_tcp.sh

--- a/tests/leonardo/in_udp.sh
+++ b/tests/leonardo/in_udp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export SINK_PORT="5170"
+
+source ./setup.sh
+
+exec_source_after_sink_launches ./sources/shell_udp.sh &
+
+./sinks/fb_udp.sh

--- a/tests/leonardo/producers/json_log_record_producer.sh
+++ b/tests/leonardo/producers/json_log_record_producer.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while [ 1 ] 
+do
+	echo '{"timestamp": 0, "msg": "test data"}'
+	sleep 1
+done

--- a/tests/leonardo/setup.sh
+++ b/tests/leonardo/setup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+source ./base.sh
+
+if [ ! -z "${ELEVATE_PRIVILEGES}" ]
+then
+    elevate_privileges
+fi
+
+trap teardown EXIT
+
+CONTEXT_PATH="/tmp/fluent-bit-test-context/"
+
+if [ -z "${FLUENT_BIT_BINARY_PATH}" ]
+then
+    if [ -f "./bin/fluent-bit" ]
+    then
+        export FLUENT_BIT_BINARY_PATH="./bin/fluent-bit"
+    elif [ -f "./fluent-bit" ]
+    then
+        export FLUENT_BIT_BINARY_PATH="./fluent-bit"
+    elif [ -f "../bin/fluent-bit" ]
+    then
+        export FLUENT_BIT_BINARY_PATH="../bin/fluent-bit"
+    elif [ -f "../fluent-bit" ]
+    then
+        export FLUENT_BIT_BINARY_PATH="../fluent-bit"
+    else
+        echo "fluent-bit could not be found, please provide a valid binary path in FLUENT_BIT_BINARY_PATH"
+        exit 1
+    fi
+
+    echo "FLUENT_BIT_BINARY_PATH not set, defaulting to ${FLUENT_BIT_BINARY_PATH}"
+fi
+
+export CONTEXT_PATH="$(realpath ${CONTEXT_PATH})/"
+
+if [ ! -d "${CONTEXT_PATH}" ]
+then
+    mkdir -p "${CONTEXT_PATH}"
+fi
+
+if [ -z ${SOURCE_PATH} ]
+then
+    export SOURCE_PATH="${CONTEXT_PATH}/source.log"
+
+    echo "SOURCE_PATH not set, defaulting to ${SOURCE_PATH}" 
+fi
+
+if [ -z ${SINK_ADDRESS} ]
+then
+    export SINK_ADDRESS="192.168.1.2"
+
+    echo "SINK_ADDRESS not set, defaulting to ${SINK_ADDRESS}" 
+fi
+
+if [ -z ${SOURCE_ADDRESS} ]
+then
+    export SOURCE_ADDRESS="192.168.1.2"
+
+    echo "SOURCE_ADDRESS not set, defaulting to ${SOURCE_ADDRESS}" 
+fi

--- a/tests/leonardo/sinks/fb_collectd.sh
+++ b/tests/leonardo/sinks/fb_collectd.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      collectd
+    listen    0.0.0.0
+    port      25826
+    typesdb   ${CONTEXT_PATH}/types.db
+
+[OUTPUT]
+    name      stdout
+    match     *
+__EOF__
+
+if [ ! -f ${CONTEXT_PATH}/types.db ] 
+then
+    wget -q https://raw.githubusercontent.com/collectd/collectd/main/src/types.db -O ${CONTEXT_PATH}/types.db
+fi
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit.conf

--- a/tests/leonardo/sinks/fb_elasticsearch.sh
+++ b/tests/leonardo/sinks/fb_elasticsearch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      elasticsearch
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_forward.sh
+++ b/tests/leonardo/sinks/fb_forward.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level trace
+
+[INPUT]
+    name      forward
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_http.sh
+++ b/tests/leonardo/sinks/fb_http.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      http
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_https.sh
+++ b/tests/leonardo/sinks/fb_https.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name         http
+    listen       0.0.0.0
+    port         ${SINK_PORT}
+    tls          on
+    tls.verify   off
+    tls.crt_file ${CONTEXT_PATH}/certificate.pem
+    tls.key_file ${CONTEXT_PATH}/private_key.pem
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_mqtt.sh
+++ b/tests/leonardo/sinks/fb_mqtt.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+SINK_PORT="1883"
+
+cat >"${CONTEXT_PATH}/fluent-bit.conf" <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      mqtt
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c "${CONTEXT_PATH}/fluent-bit.conf"

--- a/tests/leonardo/sinks/fb_otlp.sh
+++ b/tests/leonardo/sinks/fb_otlp.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      opentelemetry
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_otlp_filter_alter_size_1.sh
+++ b/tests/leonardo/sinks/fb_otlp_filter_alter_size_1.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      opentelemetry
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+
+[FILTER]
+    name      alter_size
+    match     *    
+    add       1
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_otlp_filter_alter_size_2.sh
+++ b/tests/leonardo/sinks/fb_otlp_filter_alter_size_2.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      opentelemetry
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+
+[FILTER]
+    name      alter_size
+    match     *    
+    remove    1
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_otlp_filter_checklist.sh
+++ b/tests/leonardo/sinks/fb_otlp_filter_checklist.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/checklist.txt <<__EOF__
+%papers
+__EOF__
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level trace
+
+[INPUT]
+    name      opentelemetry
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+
+[FILTER]
+    name       checklist
+    match      *
+    file       ${CONTEXT_PATH}/checklist.txt
+    mode       partial
+    lookup_key \$message
+    record     match_signal found
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_otlp_filter_expect.sh
+++ b/tests/leonardo/sinks/fb_otlp_filter_expect.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      opentelemetry
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+
+[FILTER]
+    name         expect
+    match        *    
+    key_exists   message
+    action       result_key
+    result_key   match_flag
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_otlp_filter_modify_1.sh
+++ b/tests/leonardo/sinks/fb_otlp_filter_modify_1.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      dummy
+    samples   1 
+    dummy     {"message": "sample data line"}
+    metadata  {"an interesting attribute": "this is not"}
+
+[INPUT]
+    name      dummy
+    samples   1 
+    dummy     {"log": "sample data line"}
+    metadata  {"an interesting attribute": "this is not"}
+
+[FILTER]
+    name      modify
+    match     *
+    add       added_key_name added_value
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_otlp_filter_modify_2.sh
+++ b/tests/leonardo/sinks/fb_otlp_filter_modify_2.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      dummy
+    samples   1 
+    dummy     {"message": "sample data line", "additional_data": 456}
+    metadata  {"an interesting attribute": "this is not"}
+
+[INPUT]
+    name      dummy
+    samples   1 
+    dummy     {"log": "sample data line", "additional_data": 123}
+    metadata  {"an interesting attribute": "this is not"}
+
+[FILTER]
+    name      modify
+    match     *
+    remove    additional_data
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_otlp_filter_rewrite_tag.sh
+++ b/tests/leonardo/sinks/fb_otlp_filter_rewrite_tag.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      dummy
+    samples   1 
+    dummy     {"message": "sample data line", "additional_data": "456"}
+
+[INPUT]
+    name      dummy
+    samples   1 
+    dummy     {"log": "sample data line", "additional_data": "123"}
+
+
+[FILTER]
+    Name         rewrite_tag
+    Match        dummy.*
+    rule         \$additional_data ^(123)$ 789 false
+    emitter_name re_emitter
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_otlp_filter_throttle.sh
+++ b/tests/leonardo/sinks/fb_otlp_filter_throttle.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      dummy
+    samples   10
+    rate      1
+    dummy     {"message": "sample data line"}
+    metadata  {"an interesting attribute": "this is not"}
+
+[FILTER]
+    name         throttle
+    match        *
+    window       5  
+    interval     2m
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_prometheus.sh
+++ b/tests/leonardo/sinks/fb_prometheus.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name            prometheus_scrape
+    listen          ${SOURCE_ADDRESS}
+    port            ${SOURCE_PORT}
+    metrics_path    /v1/metrics
+    scrape_interval 5
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_serial.sh
+++ b/tests/leonardo/sinks/fb_serial.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      serial
+    file      ${CONTEXT_PATH}/virtual_serial.dev
+    bitrate   9600
+    format    json
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_statsd.sh
+++ b/tests/leonardo/sinks/fb_statsd.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+SINK_PORT="8125"
+
+cat >${CONTEXT_PATH}/fluent-bit.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      statsd
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit.conf

--- a/tests/leonardo/sinks/fb_stdin.sh
+++ b/tests/leonardo/sinks/fb_stdin.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink-parsers.conf <<__EOF__
+[PARSER]
+    Name   json
+    Format json
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+__EOF__
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush        1
+    grace        1
+    log_level    info
+    parsers_file ${CONTEXT_PATH}/fluent-bit-sink-parsers.conf
+
+[INPUT]
+    name         stdin
+    parser       json
+
+[OUTPUT]
+    name         stdout
+    match        *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_syslog.sh
+++ b/tests/leonardo/sinks/fb_syslog.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink-parsers.conf <<__EOF__
+[PARSER]
+    name        syslog-rfc5424
+    format      regex
+    regex       ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+)$
+    time_key    time
+    time_format %Y-%m-%dT%H:%M:%S.%L%z
+    time_keep   On
+__EOF__
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush        1
+    grace        1
+    log_level    info
+    parsers_file ${CONTEXT_PATH}/fluent-bit-sink-parsers.conf
+
+[INPUT]
+    name         syslog
+    listen       0.0.0.0
+    port         ${SINK_PORT}
+    mode         tcp
+    parser       syslog-rfc5424
+
+[OUTPUT]
+    name         stdout
+    match        *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_tail.sh
+++ b/tests/leonardo/sinks/fb_tail.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink-parsers.conf <<__EOF__
+[PARSER]
+    name             json
+    format           json
+    time_key         time
+    time_format      %d/%b/%Y:%H:%M:%S %z
+__EOF__
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush            1
+    grace            1
+    log_level        trace
+    parsers_file     ${CONTEXT_PATH}/fluent-bit-sink-parsers.conf
+
+[INPUT]
+    name             tail
+    path             ${SOURCE_PATH}
+    read_from_head   true
+    refresh_interval 5
+    parser           json
+
+[OUTPUT]
+    name             stdout
+    match            *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_tail_multiline.sh
+++ b/tests/leonardo/sinks/fb_tail_multiline.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink-parsers.conf <<__EOF__
+[MULTILINE_PARSER]
+    name             multiline-regex-test
+    type             regex
+    rule             "start_state"   "/(Dec \d+ \d+\:\d+\:\d+)(.*)/"  "cont"
+    rule             "cont"          "/^\s+at.*/"                     "cont"
+__EOF__
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush            1
+    grace            1
+    log_level        info
+    parsers_file     ${CONTEXT_PATH}/fluent-bit-sink-parsers.conf
+
+[INPUT]
+    name             tail
+    path             ${SOURCE_PATH}
+    read_from_head   true
+    refresh_interval 5
+
+    multiline.parser go, multiline-regex-test
+    path_key         source
+    offset_key       file_offset    
+
+[OUTPUT]
+    name             stdout
+    match            *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_tail_multiline_legacy.sh
+++ b/tests/leonardo/sinks/fb_tail_multiline_legacy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink-parsers.conf <<__EOF__
+[PARSER]
+    Name             multiline-legacy-test
+    Format           regex
+    Regex            /(?<time>Dec \d+ \d+\:\d+\:\d+)(?<message>.*)/
+    Time_Key         time
+    Time_Format      %b %d %H:%M:%S
+__EOF__
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush            1
+    grace            1
+    log_level        trace
+    parsers_file     ${CONTEXT_PATH}/fluent-bit-sink-parsers.conf
+
+[INPUT]
+    name             tail
+    path             ${SOURCE_PATH}
+    read_from_head   true
+    refresh_interval 5
+
+    multiline        on 
+    parser_firstline multiline-legacy-test
+
+[OUTPUT]
+    name             stdout
+    match            *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_tcp.sh
+++ b/tests/leonardo/sinks/fb_tcp.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      tcp
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+    format    json
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sinks/fb_udp.sh
+++ b/tests/leonardo/sinks/fb_udp.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cat >${CONTEXT_PATH}/fluent-bit-sink.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      udp
+    listen    0.0.0.0
+    port      ${SINK_PORT}
+    format    json
+
+[OUTPUT]
+    name      stdout
+    match     *    
+__EOF__
+
+${FLUENT_BIT_BINARY_PATH} -c ${CONTEXT_PATH}/fluent-bit-sink.conf

--- a/tests/leonardo/sources/collectd.sh
+++ b/tests/leonardo/sources/collectd.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "The collectd source will connect to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+cat >${CONTEXT_PATH}/collectd.conf <<__EOF__
+LoadPlugin cpu
+LoadPlugin df
+LoadPlugin entropy
+LoadPlugin load
+LoadPlugin memory
+LoadPlugin processes
+LoadPlugin network
+
+<Plugin "network">
+  Server "${SINK_ADDRESS}" "${SINK_PORT}"
+</Plugin>
+__EOF__
+
+docker run -i \
+           --privileged \
+           -v ${CONTEXT_PATH}/:/etc/collectd:ro \
+           -v /proc:/mnt/proc:ro \
+           fr3nd/collectd

--- a/tests/leonardo/sources/fb_elasticsearch.sh
+++ b/tests/leonardo/sources/fb_elasticsearch.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+echo "The elasticsearch source will connect to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+cat >${CONTEXT_PATH}/fluent-bit-source.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      dummy
+    samples   1
+
+[OUTPUT]
+    name      es
+    match     *
+    host      ${SINK_ADDRESS}
+    port      ${SINK_PORT}
+    workers   0
+__EOF__
+
+docker run -i \
+           -v ${CONTEXT_PATH}/fluent-bit-source.conf:/etc/fluent-bit/fluent-bit.conf \
+           fluent/fluent-bit:latest \
+           -c /etc/fluent-bit/fluent-bit.conf

--- a/tests/leonardo/sources/fb_forward_forward_mode.sh
+++ b/tests/leonardo/sources/fb_forward_forward_mode.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+echo "The forward mode fluent forward source will connect to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+cat >${CONTEXT_PATH}/fluent-bit-source.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      dummy
+    samples   1
+
+[OUTPUT]
+    name      forward
+    match     *
+    host      ${SINK_ADDRESS}
+    port      ${SINK_PORT}
+    workers   0
+__EOF__
+
+docker run -i \
+           -v ${CONTEXT_PATH}/fluent-bit-source.conf:/etc/fluent-bit/fluent-bit.conf \
+           fluent/fluent-bit:latest \
+           -c /etc/fluent-bit/fluent-bit.conf

--- a/tests/leonardo/sources/fb_forward_legacy_mode.sh
+++ b/tests/leonardo/sources/fb_forward_legacy_mode.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "The legacy mode fluent forward source will deliver to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+cat >${CONTEXT_PATH}/fluent-bit-source.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      dummy
+    samples   1
+
+[OUTPUT]
+    name            forward
+    match           *
+    host            ${SINK_ADDRESS}
+    port            ${SINK_PORT}
+    workers         0
+    time_as_integer on
+__EOF__
+
+docker run -i \
+           -v ${CONTEXT_PATH}/fluent-bit-source.conf:/etc/fluent-bit/fluent-bit.conf \
+           fluent/fluent-bit:latest \
+           -c /etc/fluent-bit/fluent-bit.conf

--- a/tests/leonardo/sources/fb_forward_message_mode.sh
+++ b/tests/leonardo/sources/fb_forward_message_mode.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "The message mode fluent forward source will deliver to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+cat >${CONTEXT_PATH}/fluent-bit-source.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name      dummy
+    samples   1
+
+[OUTPUT]
+    name      forward
+    match     *
+    host      ${SINK_ADDRESS}
+    port      ${SINK_PORT}
+    workers   0
+    tag       test
+__EOF__
+
+docker run -i \
+           -v ${CONTEXT_PATH}/fluent-bit-source.conf:/etc/fluent-bit/fluent-bit.conf \
+           fluent/fluent-bit:latest \
+           -c /etc/fluent-bit/fluent-bit.conf

--- a/tests/leonardo/sources/fb_prometheus.sh
+++ b/tests/leonardo/sources/fb_prometheus.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+echo "The prometheus source will listen on ${SINK_ADDRESS} at ${SINK_PORT}"
+
+cat >${CONTEXT_PATH}/fluent-bit-source.conf <<__EOF__
+[SERVICE]
+    flush     1
+    grace     1
+    log_level info
+
+[INPUT]
+    name node_exporter_metrics
+
+[OUTPUT]
+    name      prometheus_exporter
+    match     *
+    host      0.0.0.0
+    port      ${SINK_PORT}
+    workers   0
+__EOF__
+
+docker run -i \
+           -v ${CONTEXT_PATH}/fluent-bit-source.conf:/etc/fluent-bit/fluent-bit.conf \
+           -p ${SINK_PORT}:${SINK_PORT} \
+           fluent/fluent-bit:latest \
+           -c /etc/fluent-bit/fluent-bit.conf

--- a/tests/leonardo/sources/otelcol_otlp_logs.sh
+++ b/tests/leonardo/sources/otelcol_otlp_logs.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+echo "The OTLP exporter will try to connect to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+cat >${CONTEXT_PATH}/otlp-logs-source.yaml <<__EOF__
+receivers:
+  filelog:
+    include: [ /var/log/otlp-input.log ]
+    start_at: beginning
+exporters:
+  logging:
+    loglevel: debug
+
+  otlphttp:
+    endpoint: "http://${SINK_ADDRESS}:${SINK_PORT}"
+    compression: none
+
+processors:
+  attributes:
+    actions:
+      - key: "attribute 1"
+        value: "string value"
+        action: insert
+      - key: "attribute 2"
+        value: 999
+        action: insert
+      - key: "attribute 3"
+        value: 66.6
+        action: insert
+      - key: "attribute 4"
+        value: false
+        action: insert
+      - key: "attribute 5"
+        value: [1, 2, 3, 4]
+        action: insert
+      - key: "attribute 6"
+        value: 
+          sub_key_1: "test"
+          sub_key_2: 111
+          sub_key_3: 2.2
+          sub_key_4: false
+        action: insert
+
+service:
+  telemetry:
+    metrics:
+      level: none
+      
+  pipelines:
+    logs:
+      receivers: [filelog]
+      processors: [attributes]
+      exporters: [otlphttp, logging]
+__EOF__
+
+cat >${CONTEXT_PATH}/otlp-input.log <<__EOF__
+test log line 1 | rocks
+test log line 2 | papers
+test log line 3 | scissors
+__EOF__
+
+docker run -i \
+           -v ${CONTEXT_PATH}/otlp-logs-source.yaml:/etc/otelcol/config.yaml \
+           -v ${CONTEXT_PATH}/otlp-input.log:/var/log/otlp-input.log \
+           otel/opentelemetry-collector-contrib:0.73.0 \
+           --config /etc/otelcol/config.yaml

--- a/tests/leonardo/sources/shell_http.sh
+++ b/tests/leonardo/sources/shell_http.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "The http source will connect to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+while [ 1 ]
+do
+  curl -k http://${SINK_ADDRESS}:${SINK_PORT} \
+       -H 'Content-type: application/json' \
+       -d '{"timestamp": 1679302100, "log": "test log data"}'
+  sleep 1
+done

--- a/tests/leonardo/sources/shell_https.sh
+++ b/tests/leonardo/sources/shell_https.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SINK_PORT="9880"
+
+echo "The https source will connect to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+while [ 1 ] ; 
+do
+  curl -k https://${SINK_ADDRESS}:${SINK_PORT} \
+       -H 'Content-type: application/json' \
+       -d '{"timestamp": 1679302100, "log": "test log data"}'
+  sleep 1
+done

--- a/tests/leonardo/sources/shell_mqtt.sh
+++ b/tests/leonardo/sources/shell_mqtt.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SINK_PORT="1883"
+
+echo "The MQTT source will to connect to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+while [ 1 ]
+do
+	mosquitto_pub -h ${SINK_ADDRESS} \
+	              -t 'test_topic' \
+	              -m '{"message": "this is a test value"}'
+	sleep 1
+done

--- a/tests/leonardo/sources/shell_serial.sh
+++ b/tests/leonardo/sources/shell_serial.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SINK_PATH="${CONTEXT_PATH}/virtual_serial.dev"
+
+echo "The serial source will listen on ${SINK_PATH}"
+
+socat -d -d -v pty,rawer,link=${SINK_PATH} EXEC:./producers/json_log_record_producer.sh,pty,rawer

--- a/tests/leonardo/sources/shell_stdin.sh
+++ b/tests/leonardo/sources/shell_stdin.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./producers/json_log_record_producer.sh

--- a/tests/leonardo/sources/shell_syslog.sh
+++ b/tests/leonardo/sources/shell_syslog.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "The syslog source will connect to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+while [ 1 ]
+do
+  logger -T -P ${SINK_PORT} -n ${SINK_ADDRESS} --rfc5424 "test log data"
+  sleep 1
+done

--- a/tests/leonardo/sources/shell_tail.sh
+++ b/tests/leonardo/sources/shell_tail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "The tail multiline source will deliver to ${SOURCE_PATH}"
+
+while [ 1 ]
+do
+    cat >${SOURCE_PATH} <<__EOF__
+{"timestamp": 0, "msg": "record 1"}
+{"timestamp": 0, "msg": "record 2"}
+{"timestamp": 0, "msg": "record 3"}
+{"timestamp": 0, "msg": "record 4"}
+{"timestamp": 0, "msg": "record 5"}
+__EOF__
+
+    break
+    sleep 1
+done

--- a/tests/leonardo/sources/shell_tail_multiline.sh
+++ b/tests/leonardo/sources/shell_tail_multiline.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+echo "The tail multiline source will deliver to ${SOURCE_PATH}"
+
+while [ 1 ]
+do
+    cat >${SOURCE_PATH} <<__EOF__
+single line...
+Dec 14 06:41:08 Exception in thread "main" java.lang.RuntimeException: Something has gone wrong, aborting!
+    at com.myproject.module.MyProject.badMethod(MyProject.java:22)
+    at com.myproject.module.MyProject.oneMoreMethod(MyProject.java:18)
+    at com.myproject.module.MyProject.anotherMethod(MyProject.java:14)
+    at com.myproject.module.MyProject.someMethod(MyProject.java:10)
+    at com.myproject.module.MyProject.main(MyProject.java:6)
+another line...
+panic: my panic
+
+goroutine 4 [running]:
+panic(0x45cb40, 0x47ad70)
+  /usr/local/go/src/runtime/panic.go:542 +0x46c fp=0xc42003f7b8 sp=0xc42003f710 pc=0x422f7c
+main.main.func1(0xc420024120)
+  foo.go:6 +0x39 fp=0xc42003f7d8 sp=0xc42003f7b8 pc=0x451339
+runtime.goexit()
+  /usr/local/go/src/runtime/asm_amd64.s:2337 +0x1 fp=0xc42003f7e0 sp=0xc42003f7d8 pc=0x44b4d1
+created by main.main
+  foo.go:5 +0x58
+
+goroutine 1 [chan receive]:
+runtime.gopark(0x4739b8, 0xc420024178, 0x46fcd7, 0xc, 0xc420028e17, 0x3)
+  /usr/local/go/src/runtime/proc.go:280 +0x12c fp=0xc420053e30 sp=0xc420053e00 pc=0x42503c
+runtime.goparkunlock(0xc420024178, 0x46fcd7, 0xc, 0x1000f010040c217, 0x3)
+  /usr/local/go/src/runtime/proc.go:286 +0x5e fp=0xc420053e70 sp=0xc420053e30 pc=0x42512e
+runtime.chanrecv(0xc420024120, 0x0, 0xc420053f01, 0x4512d8)
+  /usr/local/go/src/runtime/chan.go:506 +0x304 fp=0xc420053f20 sp=0xc420053e70 pc=0x4046b4
+runtime.chanrecv1(0xc420024120, 0x0)
+  /usr/local/go/src/runtime/chan.go:388 +0x2b fp=0xc420053f50 sp=0xc420053f20 pc=0x40439b
+main.main()
+  foo.go:9 +0x6f fp=0xc420053f80 sp=0xc420053f50 pc=0x4512ef
+runtime.main()
+  /usr/local/go/src/runtime/proc.go:185 +0x20d fp=0xc420053fe0 sp=0xc420053f80 pc=0x424bad
+runtime.goexit()
+  /usr/local/go/src/runtime/asm_amd64.s:2337 +0x1 fp=0xc420053fe8 sp=0xc420053fe0 pc=0x44b4d1
+
+goroutine 2 [force gc (idle)]:
+runtime.gopark(0x4739b8, 0x4ad720, 0x47001e, 0xf, 0x14, 0x1)
+  /usr/local/go/src/runtime/proc.go:280 +0x12c fp=0xc42003e768 sp=0xc42003e738 pc=0x42503c
+runtime.goparkunlock(0x4ad720, 0x47001e, 0xf, 0xc420000114, 0x1)
+  /usr/local/go/src/runtime/proc.go:286 +0x5e fp=0xc42003e7a8 sp=0xc42003e768 pc=0x42512e
+runtime.forcegchelper()
+  /usr/local/go/src/runtime/proc.go:238 +0xcc fp=0xc42003e7e0 sp=0xc42003e7a8 pc=0x424e5c
+runtime.goexit()
+  /usr/local/go/src/runtime/asm_amd64.s:2337 +0x1 fp=0xc42003e7e8 sp=0xc42003e7e0 pc=0x44b4d1
+created by runtime.init.4
+  /usr/local/go/src/runtime/proc.go:227 +0x35
+
+goroutine 3 [GC sweep wait]:
+runtime.gopark(0x4739b8, 0x4ad7e0, 0x46fdd2, 0xd, 0x419914, 0x1)
+  /usr/local/go/src/runtime/proc.go:280 +0x12c fp=0xc42003ef60 sp=0xc42003ef30 pc=0x42503c
+runtime.goparkunlock(0x4ad7e0, 0x46fdd2, 0xd, 0x14, 0x1)
+  /usr/local/go/src/runtime/proc.go:286 +0x5e fp=0xc42003efa0 sp=0xc42003ef60 pc=0x42512e
+runtime.bgsweep(0xc42001e150)
+  /usr/local/go/src/runtime/mgcsweep.go:52 +0xa3 fp=0xc42003efd8 sp=0xc42003efa0 pc=0x419973
+runtime.goexit()
+  /usr/local/go/src/runtime/asm_amd64.s:2337 +0x1 fp=0xc42003efe0 sp=0xc42003efd8 pc=0x44b4d1
+created by runtime.gcenable
+  /usr/local/go/src/runtime/mgc.go:216 +0x58
+one more line, no multiline
+__EOF__
+
+    break
+    sleep 1
+done

--- a/tests/leonardo/sources/shell_tail_multiline_legacy.sh
+++ b/tests/leonardo/sources/shell_tail_multiline_legacy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo "The tail multiline legacy source will deliver to ${SOURCE_PATH}"
+
+while [ 1 ]
+do
+    cat >${SOURCE_PATH} <<__EOF__
+Dec 14 06:41:08 Exception in thread "main" java.lang.RuntimeException: First multiline record!
+    at com.myproject.module.MyProject.badMethod(MyProject.java:22)
+    at com.myproject.module.MyProject.oneMoreMethod(MyProject.java:18)
+    at com.myproject.module.MyProject.anotherMethod(MyProject.java:14)
+    at com.myproject.module.MyProject.someMethod(MyProject.java:10)
+    at com.myproject.module.MyProject.main(MyProject.java:6)
+Non compliant line
+Dec 15 06:41:08 Exception in thread "main" java.lang.RuntimeException: Second multiline record!
+    at com.myproject.module.MyProject.badMethod(MyProject.java:22)
+    at com.myproject.module.MyProject.oneMoreMethod(MyProject.java:18)
+    at com.myproject.module.MyProject.anotherMethod(MyProject.java:14)
+    at com.myproject.module.MyProject.someMethod(MyProject.java:10)
+    at com.myproject.module.MyProject.main(MyProject.java:6)
+Another test line
+And another one just in case
+Dec 16 06:41:08 Exception in thread "main" java.lang.RuntimeException: Third multiline record!
+    at com.myproject.module.MyProject.badMethod(MyProject.java:22)
+    at com.myproject.module.MyProject.oneMoreMethod(MyProject.java:18)
+    at com.myproject.module.MyProject.anotherMethod(MyProject.java:14)
+    at com.myproject.module.MyProject.someMethod(MyProject.java:10)
+    at com.myproject.module.MyProject.main(MyProject.java:6)
+__EOF__
+
+    break
+    sleep 1
+done

--- a/tests/leonardo/sources/shell_tcp.sh
+++ b/tests/leonardo/sources/shell_tcp.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "The tcp source will connect to ${SINK_ADDRESS}:${SINK_PORT}"
+
+socat -d -v exec:./producers/json_log_record_producer.sh,pty,rawer \
+            tcp-connect:${SINK_ADDRESS}:${SINK_PORT}

--- a/tests/leonardo/sources/shell_udp.sh
+++ b/tests/leonardo/sources/shell_udp.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "The udp source will deliver to ${SINK_ADDRESS}:${SINK_PORT}"
+
+socat -d -v exec:./producers/json_log_record_producer.sh,pty,rawer \
+            udp-datagram:${SINK_ADDRESS}:${SINK_PORT}

--- a/tests/leonardo/sources/vector_statsd.sh
+++ b/tests/leonardo/sources/vector_statsd.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+SINK_PORT="8125"
+
+echo "The statsd source will connect to ${SINK_ADDRESS} at ${SINK_PORT}"
+
+cat >${CONTEXT_PATH}/vector-source.toml <<__EOF__
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[sinks.my_sink_id]
+type = "statsd"
+inputs = [ "internal_metrics" ]
+mode = "udp"
+address = "${SINK_ADDRESS}:${SINK_PORT}"
+__EOF__
+
+docker run -i \
+           -v ${CONTEXT_PATH}/vector-source.toml:/etc/vector/vector.toml:ro \
+           timberio/vector:0.28.1-debian


### PR DESCRIPTION
Please do not merge this PR.

In order to use these tests you need to set your working directory to tests/leonardo and then execute the outer shell scripts one by one.

Each one of these will start a data source (fluent-bit, vector, opentelemetry collector, shell scripts, etc.) and a data sinc which is the fluent-bit binary we are trying to test. 

The path to the binary (as well as other settings) can be passed through environment variables, otherwise the shell script will look for fluent-bit inside the bin directory and its parents bin directory (in case this is executed inside the build directory of a fluent-bit working tree).

The scripts will automatically elevate privileges when required and also perform a crude teardown after the test is terminated.

These are manual tests, there is no automatic compliance detection at all so far and that's not the intention either.