### PR TITLE
ci: increase timeout for log-generator

### DIFF
--- a/tests/chunk-rollover/basic.bats
+++ b/tests/chunk-rollover/basic.bats
@@ -52,7 +52,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
     kubectl create -f ${BATS_TEST_DIRNAME}/resources/manifests -n "$TEST_NAMESPACE"
 
     # use 'wait' to check for Ready status in .status.conditions[]
-    kubectl wait pods -n "$TEST_NAMESPACE" -l app=log-generator --for condition=Ready --timeout=30s
+    kubectl wait pods -n "$TEST_NAMESPACE" -l app=log-generator --for condition=Ready --timeout=60s
 
     kubectl wait pods -n "$TEST_NAMESPACE" -l app=payload-receiver --for condition=Ready --timeout=30s
 


### PR DESCRIPTION
I think I mentioned on the main PR log generator is flaky sometimes it raises an issue so increased to timeout to 60 secs

https://github.com/fluent/fluent-bit-ci/actions/runs/5833754005/job/15821926580