### PR TITLE
fix hosted rbac creation issue

### DIFF
--- a/tests/chunk-rollover/resources/helm/fluentbit-basic.yaml
+++ b/tests/chunk-rollover/resources/helm/fluentbit-basic.yaml
@@ -7,6 +7,9 @@ extraVolumes:
     sizeLimit: 3Mi
 rbac:
   create: true
+# fullnameOverride is required so resources don't conflict if we are running
+# in a hosted cluster like gke where the default resource names will already exist
+fullnameOverride: fluentbit-ci-tests
 
 config:
   service: |

--- a/tests/kubernetes-plugins/resources/fluentbit-basic.yaml
+++ b/tests/kubernetes-plugins/resources/fluentbit-basic.yaml
@@ -1,5 +1,8 @@
 kind: Deployment
 replicaCount: 1
+# fullnameOverride is required so resources don't conflict if we are running
+# in a hosted cluster like gke where the default resource names will already exist
+fullnameOverride: fluentbit-ci-tests
 rbac:
   create: true
 extraVolumeMounts:


### PR DESCRIPTION
Hosted tests that need to create the `fluent-bit` ClusterRole & ClusterRoleBinding are failing in cluster's where those resources already exist. By providing the fullnameOverride the helm chart will create the role & bindings using that name instead of the default, preventing the conflict.

This is currently causing the chunk-rollover and kubernetes-plugins tests to fail as seen [here](https://github.com/fluent/fluent-bit/actions/runs/7529985864/job/20495861202?pr=8279)

With the error: 
```
# Error: rendered manifests contain a resource that already exists. Unable to continue with install: ClusterRole "fluent-bit" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "test-7529985864": current value is "test-5786596487"
```

@patrick-stephens ... I apologize for tagging you yet again, but this _should_ resolve the last little issue with CI tests. We're very close to having it back in full working order.