### PR TITLE
fix k8s ci test after using fullnameOverride

### DIFF
--- a/tests/kubernetes-plugins/basic.bats
+++ b/tests/kubernetes-plugins/basic.bats
@@ -55,7 +55,7 @@ function deploy_fluent_bit() {
         --wait
 
     try "at most 15 times every 2s " \
-        "to find 1 pods named 'fluent-bit' " \
+        "to find 1 pods named 'fluentbit-ci-tests' " \
         "with 'status' being 'running'"
 
     FLUENTBIT_POD_NAME=$(kubectl get pods -n "$TEST_NAMESPACE" -l "app.kubernetes.io/name=fluent-bit" --no-headers | awk '{ print $1 }')


### PR DESCRIPTION
Fix pod name wait after setting `fullnameOverride: fluentbit-ci-tests`

@patrick-stephens 🤦 sorry... one more of these....

Test output:
```
========================
Starting tests.
========================

Fluentbit repository: ghcr.io/fluent/fluent-bit - tag: latest


1..8
ok 1 chunk rollover test in 196000ms
ok 2 test fluent-bit forwards logs to elasticsearch default index in 74000ms
ok 3 test fluent-bit forwards logs to elasticsearch default index using http compression in 97000ms
ok 4 test fluent-bit adds k8s labels to records in 66000ms
ok 5 verify config in 4000ms
ok 6 test fluent-bit forwards logs to opensearch default index in 40000ms
ok 7 test fluent-bit forwards logs to AWS OpenSearch hosted service default index in 0ms # skip Skipping Hosted OpenSearch When 'HOSTED_OPENSEARCH_HOST=localhost'
ok 8 Verify K8S cluster accessible in 0ms


========================
All tests passed!
========================
```