### PR TITLE
remove pod delete grace-period

### DIFF
--- a/tests/kubernetes-plugins/full.bats
+++ b/tests/kubernetes-plugins/full.bats
@@ -70,7 +70,7 @@ setup() {
 teardown() {
     if [[ "${SKIP_TEARDOWN:-no}" != "yes" ]]; then
         if [[ ! -z "$TEST_POD_NAME" ]]; then
-            run kubectl delete pod $TEST_POD_NAME --grace-period 0
+            run kubectl delete pod $TEST_POD_NAME
         fi
     fi
 }

--- a/tests/kubernetes-plugins/resources/fluentbit-basic.yaml
+++ b/tests/kubernetes-plugins/resources/fluentbit-basic.yaml
@@ -16,7 +16,7 @@ extraVolumes:
 config:
   service: |
     [SERVICE]
-        Flush 5
+        Flush 0.25
         Daemon Off
         Log_Level error
         HTTP_Server On

--- a/tests/kubernetes-plugins/resources/fluentbit-full.yaml
+++ b/tests/kubernetes-plugins/resources/fluentbit-full.yaml
@@ -18,7 +18,7 @@ extraVolumes:
 config:
   service: |
     [SERVICE]
-        Flush 5
+        Flush 0.25
         Daemon Off
         Log_Level error
         HTTP_Server On


### PR DESCRIPTION
- also lowers fluent-bit flush time from 5s to 0.25s

@patrick-stephens, my impatience came back to bite me on this one. Using the --grace-period 0, didn't actually clean up the pod immediately, so it could cause the follow up tests to fail because the original tester (tail input log generation) pods were still around creating logs. This should fix it. 🙏 