### PR TITLE
fix wait for tester pod to delete

### DIFF
--- a/tests/kubernetes-plugins/full.bats
+++ b/tests/kubernetes-plugins/full.bats
@@ -70,7 +70,7 @@ setup() {
 teardown() {
     if [[ "${SKIP_TEARDOWN:-no}" != "yes" ]]; then
         if [[ ! -z "$TEST_POD_NAME" ]]; then
-            run kubectl delete pod $TEST_POD_NAME
+            run kubectl delete pod $TEST_POD_NAME --grace-period 1 --wait
         fi
     fi
 }


### PR DESCRIPTION
Adding the proper `--grace-period 1` to signify the pod generating data for tail input should be cleaned up with minimal delay. Also using the `--wait` to wait for finalizers before returning. 

```
========================
Starting tests.
========================

Fluentbit repository: ghcr.io/fluent/fluent-bit/pr-8279 - tag: 18e5eda4b644723fcfbe6a46524de8430f856fe5-debug


1..11
ok 1 chunk rollover test in 220000ms
ok 2 test fluent-bit forwards logs to elasticsearch default index in 100000ms
ok 3 test fluent-bit forwards logs to elasticsearch default index using http compression in 84000ms
ok 4 test fluent-bit adds kubernetes pod labels to records in 15000ms
ok 5 test fluent-bit adds kubernetes namespace labels to records in 16000ms
ok 6 test fluent-bit adds kubernetes pod and namespace labels to records in 15000ms
ok 7 test fluent-bit adds kubernetes pod and namespace labels to records - kubelet enabled in 15000ms
ok 8 verify config in 4000ms
ok 9 test fluent-bit forwards logs to opensearch default index in 56000ms
ok 10 test fluent-bit forwards logs to AWS OpenSearch hosted service default index in 0ms # skip Skipping Hosted OpenSearch When 'HOSTED_OPENSEARCH_HOST=localhost'
ok 11 Verify K8S cluster accessible in 0ms


========================
All tests passed!
========================
```