### PR TITLE
have kubernetes tests run full setup and teardown each run

### DIFF
--- a/tests/kubernetes-plugins/full.bats
+++ b/tests/kubernetes-plugins/full.bats
@@ -19,7 +19,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
 FLUENTBIT_POD_NAME=""
 TEST_POD_NAME=""
 
-setup_file() {
+setup() {
     # HELM_VALUES_EXTRA_FILE is a default file containing global helm
     # options that can be optionally applied on helm install/upgrade
     # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
@@ -52,26 +52,16 @@ setup_file() {
         --values "$HELM_VALUES_EXTRA_FILE" \
         --timeout "${HELM_FB_TIMEOUT:-5m0s}" \
         --wait
-}
 
-teardown_file() {
-    if [[ "${SKIP_TEARDOWN:-no}" != "yes" ]]; then
-        helm uninstall fluent-bit -n $TEST_NAMESPACE
-        run kubectl delete namespace "$TEST_NAMESPACE"
-        rm -f ${HELM_VALUES_EXTRA_FILE}
-    fi
-}
-
-setup() {
     FLUENTBIT_POD_NAME=""
     TEST_POD_NAME=""
 }
 
 teardown() {
     if [[ "${SKIP_TEARDOWN:-no}" != "yes" ]]; then
-        if [[ ! -z "$TEST_POD_NAME" ]]; then
-            run kubectl delete pod $TEST_POD_NAME --grace-period 1 --wait
-        fi
+        helm uninstall fluent-bit -n $TEST_NAMESPACE
+        run kubectl delete namespace "$TEST_NAMESPACE"
+        rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
 }
 


### PR DESCRIPTION
I was using `setup_file`/`teardown_file` to only have to set up fluent-bit once and then run several tests on it. However, I am getting some timing issues on the kind clusters during ci runs where the test pods that are being `kubectl delete pod <name> --grace-period 1 --wait` are somehow still around and creating output that is being picked up by fluent-bit more than 10s later. 

I unfortunately can not recreate this behavior on my kind test clusters (I tried both the latest v1.27.3 as well as v1.23.5), so not sure if it's a kubectl version difference (I'm using 1.27.9) on the wait/grace-period params or if I'm just doing something completely incorrect with those params, but seeing as I could not debug it from [here](https://github.com/fluent/fluent-bit/actions/runs/7611637100/job/20727877660?pr=8279). I'll just separate the tests where they do a full cleanup and redeploy on each test, which unfortunately will add 2 minutes to our test runs, but should resolve the issue.

@patrick-stephens if you have any ideas/suggestions let me know. The CI runs are >10m each at this point and we're only running 11 tests. I looked into `bats --jobs <num> --no-parallelize-within-files` to see if we could have multiple tests run at the same time, I think it's do-able but we'd have to have each test create it's own TEST_NAMESPACE instead of sharing one. There would probably be some other structured changes to ensure any helms that create cluster-wide resources are doing so with different resource names (similar to fluent-bit helm's fullnameOverride param) otherwise those would also fail. 