### PR TITLE
delete pods from the TEST_NAMESPACE in kubernetes-plugins

### DIFF
--- a/tests/kubernetes-plugins/full.bats
+++ b/tests/kubernetes-plugins/full.bats
@@ -70,7 +70,7 @@ setup() {
 teardown() {
     if [[ "${SKIP_TEARDOWN:-no}" != "yes" ]]; then
         if [[ ! -z "$TEST_POD_NAME" ]]; then
-            run kubectl delete pod $TEST_POD_NAME --grace-period 1 --wait
+            run kubectl delete pod $TEST_POD_NAME -n $TEST_NAMESPACE --grace-period 1 --wait
         fi
     fi
 }


### PR DESCRIPTION
@patrick-stephens I missed the `-n $TEST_NAMESPACE` param in my delete. I apologize for all of the small patches here.