### PR TITLE
Parallelize tests by filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The following is the list of environment variables that controls the behavior
 of running the test suites:
 
 ```bash
-SKIP_TEARDOWN=yes # don't remove the testing namespace
-TEST_NAMESPACE=test # k8s namespace to use
+SKIP_TEARDOWN=yes # don't remove the testing namespace(s)
+TEST_NAMESPACE=test # k8s namespace to use, setting this env to any value forces tests to run in sequence
 # HELM_VALUES_EXTRA_FILE is a default file containing global helm
 # options that can be optionally applied on helm install/upgrade
 # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
@@ -65,6 +65,10 @@ TEST_NAMESPACE=test # k8s namespace to use
 HELM_VALUES_EXTRA_FILE=./path/to/your/default/values.yaml
 # The BATS formatter to use: https://bats-core.readthedocs.io/en/stable/usage.html
 BATS_FORMATTER=tap
+#BATS_JOBS_PARAMS (default below) will run 8 tests in parallel,
+# this can be disabled by changing this variable OR by setting a TEST_NAMESPACE env
+# which will force jobs to run in sequence
+BATS_JOBS_PARAMS="--jobs 8 --no-parallelize-within-files"
 # The Fluent Bit image to use
 FLUENTBIT_IMAGE_REPOSITORY=ghcr.io/fluent/fluent-bit
 FLUENTBIT_IMAGE_TAG=latest

--- a/helpers/test-helpers.bash
+++ b/helpers/test-helpers.bash
@@ -108,7 +108,9 @@ function create_helm_extra_values_file() {
     # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
     # if not passed.
     if [ -e  "${HELM_VALUES_EXTRA_FILE}" ]; then
+      # shellcheck disable=SC2086,SC2155
       envsubst < "${HELM_VALUES_EXTRA_FILE}" > "$(dirname ${HELM_VALUES_EXTRA_FILE})/${TEST_NAMESPACE}.values.yaml"
+      # shellcheck disable=SC2086,SC2155
       export HELM_VALUES_EXTRA_FILE="$(dirname ${HELM_VALUES_EXTRA_FILE})/${TEST_NAMESPACE}.values.yaml"
     fi
 }

--- a/helpers/test-helpers.bash
+++ b/helpers/test-helpers.bash
@@ -101,3 +101,14 @@ function wait_for_url() {
     # shellcheck disable=SC2086
     wait_for_curl "$MAX_ATTEMPTS" "$URL" $extra_args
 }
+
+function create_helm_extra_values_file() {
+    # HELM_VALUES_EXTRA_FILE is a default file containing global helm
+    # options that can be optionally applied on helm install/upgrade
+    # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
+    # if not passed.
+    if [ -e  "${HELM_VALUES_EXTRA_FILE}" ]; then
+      envsubst < "${HELM_VALUES_EXTRA_FILE}" > "$(dirname ${HELM_VALUES_EXTRA_FILE})/${TEST_NAMESPACE}.values.yaml"
+      export HELM_VALUES_EXTRA_FILE="$(dirname ${HELM_VALUES_EXTRA_FILE})/${TEST_NAMESPACE}.values.yaml"
+    fi
+}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -30,7 +30,6 @@ export BATS_FILE_ROOT=$BATS_ROOT/lib/bats-file
 export BATS_SUPPORT_ROOT=$BATS_ROOT/lib/bats-support
 export BATS_ASSERT_ROOT=$BATS_ROOT/lib/bats-assert
 export BATS_DETIK_ROOT=$BATS_ROOT/lib/bats-detik
-export TEST_NAMESPACE=${TEST_NAMESPACE:-test}
 
 export FLUENTBIT_IMAGE_REPOSITORY=${FLUENTBIT_IMAGE_REPOSITORY:-ghcr.io/fluent/fluent-bit}
 export FLUENTBIT_IMAGE_TAG=${FLUENTBIT_IMAGE_TAG:-latest}
@@ -79,11 +78,18 @@ function run_tests() {
     echo
     echo
 
+    # If TEST_NAMESPACE is not set (the default), we run 8 jobs in parallel
+    # otherwise, if it is set we can only run 1 job at a time
+    BATS_JOBS_PARAMS=""
+    if [[ -z "$TEST_NAMESPACE" ]]; then
+        BATS_JOBS_PARAMS="--jobs $BATS_JOBS_COUNT --no-parallelize-within-files"
+    fi
+
     # We run BATS in a subshell to prevent it from inheriting our exit/err trap, which can mess up its internals
     # We set +exu because unbound variables can cause test failures with zero context
     set +xeu
     # shellcheck disable=SC2086
-    (bats --formatter "${BATS_FORMATTER}" $run $BATS_ARGS)
+    (bats $BATS_JOBS_PARAMS --formatter "${BATS_FORMATTER}" $run $BATS_ARGS)
     local bats_retval=$?
 
     echo

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -25,6 +25,7 @@ export RESOURCES_ROOT="${SCRIPT_DIR}/resources/"
 export BATS_FORMATTER=${BATS_FORMATTER:-tap}
 export BATS_ROOT=${BATS_ROOT:-$SCRIPT_DIR/tools/bats}
 export BATS_ARGS=${BATS_ARGS:---timing --verbose-run}
+export BATS_JOBS_PARAMS=${BATS_JOBS_PARAMS:---jobs 8 --no-parallelize-within-files}
 
 export BATS_FILE_ROOT=$BATS_ROOT/lib/bats-file
 export BATS_SUPPORT_ROOT=$BATS_ROOT/lib/bats-support
@@ -78,11 +79,11 @@ function run_tests() {
     echo
     echo
 
-    # If TEST_NAMESPACE is not set (the default), we run 8 jobs in parallel
-    # otherwise, if it is set we can only run 1 job at a time
-    BATS_JOBS_PARAMS=""
-    if [[ -z "$TEST_NAMESPACE" ]]; then
-        BATS_JOBS_PARAMS="--jobs $BATS_JOBS_COUNT --no-parallelize-within-files"
+    # If TEST_NAMESPACE is not set (the default), we run jobs in parallel
+    # otherwise, if it is set we can only run 1 job at a time and need to remove
+    # all BATS_JOBS_PARAMS
+    if [[ ! -z "${TEST_NAMESPACE:-}" ]]; then
+        BATS_JOBS_PARAMS=""
     fi
 
     # We run BATS in a subshell to prevent it from inheriting our exit/err trap, which can mess up its internals

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -82,7 +82,7 @@ function run_tests() {
     # If TEST_NAMESPACE is not set (the default), we run jobs in parallel
     # otherwise, if it is set we can only run 1 job at a time and need to remove
     # all BATS_JOBS_PARAMS
-    if [[ ! -z "${TEST_NAMESPACE:-}" ]]; then
+    if [[ -n "${TEST_NAMESPACE:-}" ]]; then
         BATS_JOBS_PARAMS=""
     fi
 

--- a/tests/chunk-rollover/basic.bats
+++ b/tests/chunk-rollover/basic.bats
@@ -2,7 +2,7 @@
 
 load "$HELPERS_ROOT/test-helpers.bash"
 
-ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT TEST_NAMESPACE FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG ELASTICSEARCH_IMAGE_REPOSITORY ELASTICSEARCH_IMAGE_TAG
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG ELASTICSEARCH_IMAGE_REPOSITORY ELASTICSEARCH_IMAGE_TAG
 
 load "$BATS_DETIK_ROOT/utils.bash"
 load "$BATS_DETIK_ROOT/linter.bash"
@@ -10,19 +10,13 @@ load "$BATS_DETIK_ROOT/detik.bash"
 load "$BATS_SUPPORT_ROOT/load.bash"
 load "$BATS_ASSERT_ROOT/load.bash"
 load "$BATS_FILE_ROOT/load.bash"
-
+ 
 setup_file() {
+    export TEST_NAMESPACE=${TEST_NAMESPACE:-chunk-rollover-basic}
     echo "recreating namespace $TEST_NAMESPACE"
     run kubectl delete namespace "$TEST_NAMESPACE"
     run kubectl create namespace "$TEST_NAMESPACE"
-    # HELM_VALUES_EXTRA_FILE is a default file containing global helm
-    # options that can be optionally applied on helm install/upgrade
-    # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
-    # if not passed.
-    if [ -e  "${HELM_VALUES_EXTRA_FILE}" ]; then
-      envsubst < "${HELM_VALUES_EXTRA_FILE}" > "${HELM_VALUES_EXTRA_FILE%.*}"
-      export HELM_VALUES_EXTRA_FILE="${HELM_VALUES_EXTRA_FILE%.*}"
-    fi
+    create_helm_extra_values_file
 }
 
 teardown_file() {
@@ -31,6 +25,7 @@ teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
+    unset TEST_NAMESPACE
 }
 
 function teardown() {

--- a/tests/chunk-rollover/basic.bats
+++ b/tests/chunk-rollover/basic.bats
@@ -25,7 +25,6 @@ teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
-    unset TEST_NAMESPACE
 }
 
 function teardown() {
@@ -68,7 +67,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
 
     COUNTER=0
 
-    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
+    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=60s
 
     while [ $COUNTER -lt $TOTAL_TIME ]; do
         # Get the number of Fluent Bit DaemonSet pods that are not in the "Running" status

--- a/tests/chunk-rollover/resources/helm/fluentbit-basic.yaml
+++ b/tests/chunk-rollover/resources/helm/fluentbit-basic.yaml
@@ -7,9 +7,6 @@ extraVolumes:
     sizeLimit: 3Mi
 rbac:
   create: true
-# fullnameOverride is required so resources don't conflict if we are running
-# in a hosted cluster like gke where the default resource names will already exist
-fullnameOverride: fluentbit-ci-tests
 
 config:
   service: |

--- a/tests/defaults/values.yaml.tpl
+++ b/tests/defaults/values.yaml.tpl
@@ -1,3 +1,3 @@
 image:
   pullPolicy: ${HELM_IMAGE_PULL_POLICY}
-fullnameOverride: fluentbit-ci-test-${TEST_NAMESPACE}
+fullnameOverride: fluent-bit-ci-test-${TEST_NAMESPACE}

--- a/tests/defaults/values.yaml.tpl
+++ b/tests/defaults/values.yaml.tpl
@@ -1,2 +1,3 @@
 image:
   pullPolicy: ${HELM_IMAGE_PULL_POLICY}
+fullnameOverride: fluentbit-ci-test-${TEST_NAMESPACE}

--- a/tests/elasticsearch/basic.bats
+++ b/tests/elasticsearch/basic.bats
@@ -58,7 +58,9 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --timeout "${HELM_FB_TIMEOUT:-5m0s}" \
         --wait
 
-    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
+    try "at most 15 times every 2s " \
+        "to find 1 pods named 'fluent-bit' " \
+        "with 'status' being 'running'"
 
     attempt=0
     while true; do

--- a/tests/elasticsearch/basic.bats
+++ b/tests/elasticsearch/basic.bats
@@ -26,7 +26,6 @@ teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
-    unset TEST_NAMESPACE
 }
 
 # These are required for bats-detik

--- a/tests/elasticsearch/basic.bats
+++ b/tests/elasticsearch/basic.bats
@@ -2,7 +2,7 @@
 
 load "$HELPERS_ROOT/test-helpers.bash"
 
-ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT TEST_NAMESPACE FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG ELASTICSEARCH_IMAGE_REPOSITORY ELASTICSEARCH_IMAGE_TAG
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG ELASTICSEARCH_IMAGE_REPOSITORY ELASTICSEARCH_IMAGE_TAG
 
 load "$BATS_DETIK_ROOT/utils.bash"
 load "$BATS_DETIK_ROOT/linter.bash"
@@ -12,17 +12,11 @@ load "$BATS_ASSERT_ROOT/load.bash"
 load "$BATS_FILE_ROOT/load.bash"
 
 setup_file() {
+    export TEST_NAMESPACE=${TEST_NAMESPACE:-elasticsearch-basic}
     echo "recreating namespace $TEST_NAMESPACE"
     run kubectl delete namespace "$TEST_NAMESPACE"
     run kubectl create namespace "$TEST_NAMESPACE"
-    # HELM_VALUES_EXTRA_FILE is a default file containing global helm
-    # options that can be optionally applied on helm install/upgrade
-    # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
-    # if not passed.
-    if [ -e  "${HELM_VALUES_EXTRA_FILE}" ]; then
-      envsubst < "${HELM_VALUES_EXTRA_FILE}" > "${HELM_VALUES_EXTRA_FILE%.*}"
-      export HELM_VALUES_EXTRA_FILE="${HELM_VALUES_EXTRA_FILE%.*}"
-    fi
+    create_helm_extra_values_file
 }
 
 teardown_file() {
@@ -32,6 +26,7 @@ teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
+    unset TEST_NAMESPACE
 }
 
 # These are required for bats-detik
@@ -49,7 +44,6 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
     helm upgrade --install --debug --create-namespace --namespace "$TEST_NAMESPACE" elasticsearch elastic/elasticsearch \
         --values ${BATS_TEST_DIRNAME}/resources/helm/elasticsearch-basic.yaml \
         --set image=${ELASTICSEARCH_IMAGE_REPOSITORY} --set imageTag=${ELASTICSEARCH_IMAGE_TAG} \
-        --values "$HELM_VALUES_EXTRA_FILE" \
         --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
@@ -64,9 +58,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --timeout "${HELM_FB_TIMEOUT:-5m0s}" \
         --wait
 
-    try "at most 15 times every 2s " \
-        "to find 1 pods named 'fluent-bit' " \
-        "with 'status' being 'running'"
+    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
 
     attempt=0
     while true; do

--- a/tests/elasticsearch/compress.bats
+++ b/tests/elasticsearch/compress.bats
@@ -26,7 +26,6 @@ teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
-    unset TEST_NAMESPACE
 }
 
 # These are required for bats-detik

--- a/tests/elasticsearch/compress.bats
+++ b/tests/elasticsearch/compress.bats
@@ -2,7 +2,7 @@
 
 load "$HELPERS_ROOT/test-helpers.bash"
 
-ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT TEST_NAMESPACE FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG ELASTICSEARCH_IMAGE_REPOSITORY ELASTICSEARCH_IMAGE_TAG
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG ELASTICSEARCH_IMAGE_REPOSITORY ELASTICSEARCH_IMAGE_TAG
 
 load "$BATS_DETIK_ROOT/utils.bash"
 load "$BATS_DETIK_ROOT/linter.bash"
@@ -12,17 +12,11 @@ load "$BATS_ASSERT_ROOT/load.bash"
 load "$BATS_FILE_ROOT/load.bash"
 
 setup_file() {
+    export TEST_NAMESPACE=${TEST_NAMESPACE:-elasticsearch-compress}
     echo "recreating namespace $TEST_NAMESPACE"
     run kubectl delete namespace "$TEST_NAMESPACE"
     run kubectl create namespace "$TEST_NAMESPACE"
-    # HELM_VALUES_EXTRA_FILE is a default file containing global helm
-    # options that can be optionally applied on helm install/upgrade
-    # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
-    # if not passed.
-    if [ -e  "${HELM_VALUES_EXTRA_FILE}" ]; then
-      envsubst < "${HELM_VALUES_EXTRA_FILE}" > "${HELM_VALUES_EXTRA_FILE%.*}"
-      export HELM_VALUES_EXTRA_FILE="${HELM_VALUES_EXTRA_FILE%.*}"
-    fi
+    create_helm_extra_values_file
 }
 
 teardown_file() {
@@ -32,6 +26,7 @@ teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
+    unset TEST_NAMESPACE
 }
 
 # These are required for bats-detik
@@ -49,7 +44,6 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
     helm upgrade --install --debug --create-namespace --namespace "$TEST_NAMESPACE" elasticsearch elastic/elasticsearch \
         --values ${BATS_TEST_DIRNAME}/resources/helm/elasticsearch-compress.yaml \
         --set image=${ELASTICSEARCH_IMAGE_REPOSITORY} --set imageTag=${ELASTICSEARCH_IMAGE_TAG} \
-        --values "$HELM_VALUES_EXTRA_FILE" \
         --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
@@ -64,9 +58,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
-    try "at most 15 times every 2s " \
-        "to find 1 pods named 'fluent-bit' " \
-        "with 'status' being 'running'"
+    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
 
     attempt=0
     while true; do

--- a/tests/elasticsearch/compress.bats
+++ b/tests/elasticsearch/compress.bats
@@ -58,7 +58,9 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
-    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
+    try "at most 15 times every 2s " \
+        "to find 1 pods named 'fluent-bit' " \
+        "with 'status' being 'running'"
 
     attempt=0
     while true; do

--- a/tests/kubernetes-plugins/basic.bats
+++ b/tests/kubernetes-plugins/basic.bats
@@ -62,7 +62,9 @@ teardown() {
 
 
 function set_fluent_bit_pod_name() {
-    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
+    try "at most 30 times every 2s " \
+        "to find 1 pods named 'fluent-bit' " \
+        "with 'status' being 'running'"
 
     FLUENTBIT_POD_NAME=$(kubectl get pods -n "$TEST_NAMESPACE" -l "app.kubernetes.io/name=fluent-bit" --no-headers | awk '{ print $1 }')
     if [ -z "$FLUENTBIT_POD_NAME" ]; then

--- a/tests/kubernetes-plugins/basic.bats
+++ b/tests/kubernetes-plugins/basic.bats
@@ -44,7 +44,6 @@ teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
-    unset TEST_NAMESPACE
 }
 
 setup() {

--- a/tests/kubernetes-plugins/basic.bats
+++ b/tests/kubernetes-plugins/basic.bats
@@ -2,7 +2,7 @@
 
 load "$HELPERS_ROOT/test-helpers.bash"
 
-ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT TEST_NAMESPACE FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG
 
 load "$BATS_DETIK_ROOT/utils.bash"
 load "$BATS_DETIK_ROOT/linter.bash"
@@ -20,17 +20,11 @@ FLUENTBIT_POD_NAME=""
 TEST_POD_NAME=""
 
 setup_file() {
+    export TEST_NAMESPACE=${TEST_NAMESPACE:-kubernetes-plugins-basic}
     echo "recreating namespace $TEST_NAMESPACE"
     run kubectl delete namespace "$TEST_NAMESPACE"
     run kubectl create namespace "$TEST_NAMESPACE"
-    # HELM_VALUES_EXTRA_FILE is a default file containing global helm
-    # options that can be optionally applied on helm install/upgrade
-    # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
-    # if not passed.
-    if [ -e  "${HELM_VALUES_EXTRA_FILE}" ]; then
-      envsubst < "${HELM_VALUES_EXTRA_FILE}" > "${HELM_VALUES_EXTRA_FILE%.*}"
-      export HELM_VALUES_EXTRA_FILE="${HELM_VALUES_EXTRA_FILE%.*}"
-    fi
+    create_helm_extra_values_file
 
     helm repo add fluent https://fluent.github.io/helm-charts/ || helm repo add fluent https://fluent.github.io/helm-charts
     helm repo update --fail-on-repo-update-fail
@@ -50,6 +44,7 @@ teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
+    unset TEST_NAMESPACE
 }
 
 setup() {
@@ -67,9 +62,7 @@ teardown() {
 
 
 function set_fluent_bit_pod_name() {
-    try "at most 30 times every 2s " \
-        "to find 1 pods named 'fluentbit-ci-tests' " \
-        "with 'status' being 'Running'"
+    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
 
     FLUENTBIT_POD_NAME=$(kubectl get pods -n "$TEST_NAMESPACE" -l "app.kubernetes.io/name=fluent-bit" --no-headers | awk '{ print $1 }')
     if [ -z "$FLUENTBIT_POD_NAME" ]; then

--- a/tests/kubernetes-plugins/full.bats
+++ b/tests/kubernetes-plugins/full.bats
@@ -71,8 +71,10 @@ teardown() {
 }
 
 function set_fluent_bit_pod_name() {
-    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
-    
+    try "at most 30 times every 2s " \
+        "to find 1 pods named 'fluent-bit' " \
+        "with 'status' being 'running'"
+
     FLUENTBIT_POD_NAME=$(kubectl get pods -n "$TEST_NAMESPACE" -l "app.kubernetes.io/name=fluent-bit" --no-headers | awk '{ print $1 }')
     if [ -z "$FLUENTBIT_POD_NAME" ]; then
         fail "Unable to get running fluent-bit pod's name"

--- a/tests/kubernetes-plugins/full.bats
+++ b/tests/kubernetes-plugins/full.bats
@@ -54,7 +54,6 @@ teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
-    unset TEST_NAMESPACE
 }
 
 setup() {

--- a/tests/kubernetes-plugins/full.bats
+++ b/tests/kubernetes-plugins/full.bats
@@ -2,7 +2,7 @@
 
 load "$HELPERS_ROOT/test-helpers.bash"
 
-ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT TEST_NAMESPACE FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG
 
 load "$BATS_DETIK_ROOT/utils.bash"
 load "$BATS_DETIK_ROOT/linter.bash"
@@ -20,14 +20,8 @@ FLUENTBIT_POD_NAME=""
 TEST_POD_NAME=""
 
 setup_file() {
-    # HELM_VALUES_EXTRA_FILE is a default file containing global helm
-    # options that can be optionally applied on helm install/upgrade
-    # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
-    # if not passed.
-    if [ -e  "${HELM_VALUES_EXTRA_FILE}" ]; then
-      envsubst < "${HELM_VALUES_EXTRA_FILE}" > "${HELM_VALUES_EXTRA_FILE%.*}"
-      export HELM_VALUES_EXTRA_FILE="${HELM_VALUES_EXTRA_FILE%.*}"
-    fi
+    export TEST_NAMESPACE=${TEST_NAMESPACE:-kubernetes-plugins-full}
+    create_helm_extra_values_file
 
     # First check that we should run these conditional tests at all
     run docker run --rm -t $FLUENTBIT_IMAGE_REPOSITORY:$FLUENTBIT_IMAGE_TAG /fluent-bit/bin/fluent-bit -F kubernetes --help
@@ -60,6 +54,7 @@ teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
+    unset TEST_NAMESPACE
 }
 
 setup() {
@@ -76,9 +71,7 @@ teardown() {
 }
 
 function set_fluent_bit_pod_name() {
-    try "at most 30 times every 2s " \
-        "to find 1 pods named 'fluentbit-ci-tests' " \
-        "with 'status' being 'Running'"
+    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
     
     FLUENTBIT_POD_NAME=$(kubectl get pods -n "$TEST_NAMESPACE" -l "app.kubernetes.io/name=fluent-bit" --no-headers | awk '{ print $1 }')
     if [ -z "$FLUENTBIT_POD_NAME" ]; then

--- a/tests/kubernetes-plugins/resources/fluentbit-basic.yaml
+++ b/tests/kubernetes-plugins/resources/fluentbit-basic.yaml
@@ -1,8 +1,5 @@
 kind: Deployment
 replicaCount: 1
-# fullnameOverride is required so resources don't conflict if we are running
-# in a hosted cluster like gke where the default resource names will already exist
-fullnameOverride: fluentbit-ci-tests
 rbac:
   create: true
 extraVolumeMounts:

--- a/tests/kubernetes-plugins/resources/fluentbit-full.yaml
+++ b/tests/kubernetes-plugins/resources/fluentbit-full.yaml
@@ -1,8 +1,5 @@
 kind: Deployment
 replicaCount: 1
-# fullnameOverride is required so resources don't conflict if we are running
-# in a hosted cluster like gke where the default resource names will already exist
-fullnameOverride: fluentbit-ci-tests
 rbac:
   create: true
   nodeAccess: true

--- a/tests/opensearch/basic.bats
+++ b/tests/opensearch/basic.bats
@@ -26,7 +26,6 @@ function teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
-    unset TEST_NAMESPACE
 }
 
 function teardown() {
@@ -79,7 +78,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
     try "at most 15 times every 2s " \
         "to find 1 pods named 'fluent-bit' " \
         "with 'status' being 'running'"
-        
+
     attempt=0
     while true; do
     	run kubectl exec -q -n $TEST_NAMESPACE opensearch-cluster-master-0 -- curl --insecure -s -w "%{http_code}" https://admin:admin@localhost:9200/fluentbit/_search/ -o /dev/null

--- a/tests/opensearch/basic.bats
+++ b/tests/opensearch/basic.bats
@@ -76,8 +76,10 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --timeout "${HELM_FB_TIMEOUT:-5m0s}" \
         --wait
 
-    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
-
+    try "at most 15 times every 2s " \
+        "to find 1 pods named 'fluent-bit' " \
+        "with 'status' being 'running'"
+        
     attempt=0
     while true; do
     	run kubectl exec -q -n $TEST_NAMESPACE opensearch-cluster-master-0 -- curl --insecure -s -w "%{http_code}" https://admin:admin@localhost:9200/fluentbit/_search/ -o /dev/null

--- a/tests/opensearch/basic.bats
+++ b/tests/opensearch/basic.bats
@@ -2,7 +2,7 @@
 
 load "$HELPERS_ROOT/test-helpers.bash"
 
-ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT TEST_NAMESPACE FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG OPENSEARCH_IMAGE_REPOSITORY OPENSEARCH_IMAGE_TAG
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT FLUENTBIT_IMAGE_REPOSITORY FLUENTBIT_IMAGE_TAG OPENSEARCH_IMAGE_REPOSITORY OPENSEARCH_IMAGE_TAG
 
 load "$BATS_DETIK_ROOT/utils.bash"
 load "$BATS_DETIK_ROOT/linter.bash"
@@ -12,17 +12,11 @@ load "$BATS_ASSERT_ROOT/load.bash"
 load "$BATS_FILE_ROOT/load.bash"
 
 function setup_file() {
+    export TEST_NAMESPACE=${TEST_NAMESPACE:-opensearch-basic}
     echo "recreating namespace $TEST_NAMESPACE"
     run kubectl delete namespace "$TEST_NAMESPACE"
     run kubectl create namespace "$TEST_NAMESPACE"
-    # HELM_VALUES_EXTRA_FILE is a default file containing global helm
-    # options that can be optionally applied on helm install/upgrade
-    # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
-    # if not passed.
-    if [ -e  "${HELM_VALUES_EXTRA_FILE}" ]; then
-      envsubst < "${HELM_VALUES_EXTRA_FILE}" > "${HELM_VALUES_EXTRA_FILE%.*}"
-      export HELM_VALUES_EXTRA_FILE="${HELM_VALUES_EXTRA_FILE%.*}"
-    fi
+    create_helm_extra_values_file
 }
 
 function teardown_file() {
@@ -32,6 +26,7 @@ function teardown_file() {
         run kubectl delete namespace "$TEST_NAMESPACE"
         rm -f ${HELM_VALUES_EXTRA_FILE}
     fi
+    unset TEST_NAMESPACE
 }
 
 function teardown() {
@@ -66,7 +61,6 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
     helm upgrade --install --debug --create-namespace --namespace "$TEST_NAMESPACE" opensearch opensearch/opensearch \
         --values ${BATS_TEST_DIRNAME}/resources/helm/opensearch-basic.yaml \
         --set image.repository=${OPENSEARCH_IMAGE_REPOSITORY},image.tag=${OPENSEARCH_IMAGE_TAG} \
-        --values "$HELM_VALUES_EXTRA_FILE" \
         --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
@@ -82,9 +76,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --timeout "${HELM_FB_TIMEOUT:-5m0s}" \
         --wait
 
-    try "at most 15 times every 2s " \
-        "to find 1 pods named 'fluent-bit' " \
-        "with 'status' being 'running'"
+    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
 
     attempt=0
     while true; do

--- a/tests/opensearch/hosted.bats
+++ b/tests/opensearch/hosted.bats
@@ -60,7 +60,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
     try "at most 15 times every 2s " \
         "to find 1 pods named 'fluent-bit' " \
         "with 'status' being 'running'"
-        
+
     attempt=0
     while true; do
         run curl -XGET --header 'Content-Type: application/json' --insecure -s -w "%{http_code}" https://${HOSTED_OPENSEARCH_USERNAME}:${HOSTED_OPENSEARCH_PASSWORD}@${HOSTED_OPENSEARCH_HOST}/fluentbit/_search/ -d '{ "query": { "range": { "timestamp": { "gte": "now-15s" }}}}' -o /dev/null

--- a/tests/opensearch/hosted.bats
+++ b/tests/opensearch/hosted.bats
@@ -12,6 +12,9 @@ load "$BATS_ASSERT_ROOT/load.bash"
 load "$BATS_FILE_ROOT/load.bash"
 
 setup_file() {
+    if [[ $HOSTED_OPENSEARCH_HOST == "localhost" ]]; then
+        skip "Skipping Hosted OpenSearch When 'HOSTED_OPENSEARCH_HOST=localhost'"
+    fi
     export TEST_NAMESPACE=${TEST_NAMESPACE:-opensearch-hosted}
     echo "recreating namespace $TEST_NAMESPACE"
     run kubectl delete namespace "$TEST_NAMESPACE"
@@ -28,7 +31,6 @@ teardown_file() {
             rm -f ${BATS_TEST_DIRNAME}/resources/helm/fluentbit-hosted.yaml
         fi
     fi
-    unset TEST_NAMESPACE
 }
 
 function teardown() {
@@ -45,10 +47,6 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
 
 
 @test "test fluent-bit forwards logs to AWS OpenSearch hosted service default index" {
-    if [[ $HOSTED_OPENSEARCH_HOST == "localhost" ]]; then
-        skip "Skipping Hosted OpenSearch When 'HOSTED_OPENSEARCH_HOST=localhost'"
-    fi
-
     envsubst < "${BATS_TEST_DIRNAME}/resources/helm/fluentbit-hosted.yaml.tpl" > "${BATS_TEST_DIRNAME}/resources/helm/fluentbit-hosted.yaml"
 
     helm upgrade --install --debug --create-namespace --namespace "$TEST_NAMESPACE" fluent-bit fluent/fluent-bit \

--- a/tests/opensearch/hosted.bats
+++ b/tests/opensearch/hosted.bats
@@ -2,7 +2,7 @@
 
 load "$HELPERS_ROOT/test-helpers.bash"
 
-ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT TEST_NAMESPACE FLUENTBIT_IMAGE_TAG HOSTED_OPENSEARCH_HOST HOSTED_OPENSEARCH_PORT HOSTED_OPENSEARCH_USERNAME HOSTED_OPENSEARCH_PASSWORD
+ensure_variables_set BATS_SUPPORT_ROOT BATS_ASSERT_ROOT BATS_DETIK_ROOT BATS_FILE_ROOT FLUENTBIT_IMAGE_TAG HOSTED_OPENSEARCH_HOST HOSTED_OPENSEARCH_PORT HOSTED_OPENSEARCH_USERNAME HOSTED_OPENSEARCH_PASSWORD
 
 load "$BATS_DETIK_ROOT/utils.bash"
 load "$BATS_DETIK_ROOT/linter.bash"
@@ -12,17 +12,11 @@ load "$BATS_ASSERT_ROOT/load.bash"
 load "$BATS_FILE_ROOT/load.bash"
 
 setup_file() {
+    export TEST_NAMESPACE=${TEST_NAMESPACE:-opensearch-hosted}
     echo "recreating namespace $TEST_NAMESPACE"
     run kubectl delete namespace "$TEST_NAMESPACE"
     run kubectl create namespace "$TEST_NAMESPACE"
-    # HELM_VALUES_EXTRA_FILE is a default file containing global helm
-    # options that can be optionally applied on helm install/upgrade
-    # by the test. This will fall back to $TEST_ROOT/defaults/values.yaml.tpl
-    # if not passed.
-    if [ -e  "${HELM_VALUES_EXTRA_FILE}" ]; then
-      envsubst < "${HELM_VALUES_EXTRA_FILE}" > "${HELM_VALUES_EXTRA_FILE%.*}"
-      export HELM_VALUES_EXTRA_FILE="${HELM_VALUES_EXTRA_FILE%.*}"
-    fi
+    create_helm_extra_values_file
 }
 
 teardown_file() {
@@ -34,6 +28,7 @@ teardown_file() {
             rm -f ${BATS_TEST_DIRNAME}/resources/helm/fluentbit-hosted.yaml
         fi
     fi
+    unset TEST_NAMESPACE
 }
 
 function teardown() {
@@ -64,9 +59,7 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
-    try "at most 15 times every 2s " \
-        "to find 1 pods named 'fluent-bit' " \
-        "with 'status' being 'running'"
+    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
 
     attempt=0
     while true; do

--- a/tests/opensearch/hosted.bats
+++ b/tests/opensearch/hosted.bats
@@ -59,8 +59,10 @@ DETIK_CLIENT_NAMESPACE="${TEST_NAMESPACE}"
         --timeout "${HELM_DEFAULT_TIMEOUT:-10m0s}" \
         --wait
 
-    kubectl wait pods -n "$TEST_NAMESPACE" -l app.kubernetes.io/name=fluent-bit --for condition=Ready --timeout=30s
-
+    try "at most 15 times every 2s " \
+        "to find 1 pods named 'fluent-bit' " \
+        "with 'status' being 'running'"
+        
     attempt=0
     while true; do
         run curl -XGET --header 'Content-Type: application/json' --insecure -s -w "%{http_code}" https://${HOSTED_OPENSEARCH_USERNAME}:${HOSTED_OPENSEARCH_PASSWORD}@${HOSTED_OPENSEARCH_HOST}/fluentbit/_search/ -d '{ "query": { "range": { "timestamp": { "gte": "now-15s" }}}}' -o /dev/null


### PR DESCRIPTION
This makes a few changes to some current expectations that allows us to run tests in parallel and can speed up test runs from around 11 minutes down to 4 minutes (which could be trimmed down even further if the chunked-rollover test is re-worked and there isn't a 3 minute sleep within it).

Changes:
- Tests can be parallelized by file, by default this runs 8 jobs, to accomplish this tests run within their own namespace, by setting the `TEST_NAMESPACE` variable in their `setup_file()`. We no longer require `TEST_NAMESPACE` being set before the test is run for this reason.
- Tests also require that `fullnameOverrides` are used within the helm installs so that daemonsets or clusterroles being set up by the helm chart do not conflict when they run in parallel. This also means for tests that use multiple helms (like elasticsearch), I removed passing the extra templated helm file options passed to them as using `fullnameOverrides` conflicts and causes elasticsearch to take on the same name we're giving fluent-bit. 
- If TEST_NAMESPACE is set before calling `run-tests.sh` tests will be required to run in sequential order (as they do today), but the fullnameOverride logic above still applies.
- values.yaml.tpl env substitution requires TEST_NAMESPACE is set, which is used to create a non-conflicting templated file for the running test, a function `create_helm_extra_values_file` was also created within `test-helpers.bash` to remove some of the copy code.

```
========================
Starting tests.
========================

Fluentbit repository: ghcr.io/fluent/fluent-bit/pr-8279 - tag: 18e5eda4b644723fcfbe6a46524de8430f856fe5-debug


1..11
ok 1 chunk rollover test in 201000ms
ok 2 test fluent-bit forwards logs to elasticsearch default index in 96000ms
ok 3 test fluent-bit forwards logs to elasticsearch default index using http compression in 100000ms
ok 4 test fluent-bit adds kubernetes pod labels to records in 16000ms
ok 5 test fluent-bit adds kubernetes namespace labels to records in 17000ms
ok 6 test fluent-bit adds kubernetes pod and namespace labels to records in 17000ms
ok 7 test fluent-bit adds kubernetes pod and namespace labels to records - kubelet enabled in 0ms # skip kubelet-enabled test skipped until https://github.com/fluent/fluent-bit-ci/issues/134 is resolved
ok 8 verify config in 3000ms
ok 9 test fluent-bit forwards logs to opensearch default index in 57000ms
ok 10 test fluent-bit forwards logs to AWS OpenSearch hosted service default index in 0ms # skip Skipping Hosted OpenSearch When 'HOSTED_OPENSEARCH_HOST=localhost'
ok 11 Verify K8S cluster accessible in 0ms


========================
All tests passed!
========================


FLUENTBIT_IMAGE_REPOSITORY=ghcr.io/fluent/fluent-bit/pr-8279 = ./run-tests.sh  24.69s user 13.43s system 15% cpu 4:07.66 total
```
 