### PR TITLE
Enabled runtime tests which work locally

### DIFF
--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -11,9 +11,7 @@ nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN
 
 echo "use $ASAN_SYMBOLIZER_PATH"
 
-SKIP_TESTS="flb-rt-out_elasticsearch
-flb-rt-out_td
-flb-rt-out_forward
+SKIP_TESTS="flb-rt-out_td
 flb-rt-in_disk
 flb-rt-in_proc"
 


### PR DESCRIPTION
**Summary**

Enabled runtime tests for Forward and Elasticsearch output plugins to match run_code_analysis.sh script (from https://github.com/fluent/fluent-bit/pull/11724) used on local environment.

Note that this PR requires https://github.com/fluent/fluent-bit/pull/11724 to be merged first, because https://github.com/fluent/fluent-bit/pull/11724 fixes some of the tests enabled in this PR.

**Testing**

Refer to https://github.com/fluent/fluent-bit/pull/11724 (https://github.com/fluent/fluent-bit/actions/runs/25181471509?pr=11724).